### PR TITLE
Added console.error on every catch block

### DIFF
--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -91,6 +91,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       return resolve(send(status)({ message, status }));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       return resolve(error500(err));
     }
   },

--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -190,6 +190,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(assignmentResult.newTask));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/autopilotRedirect.protected.ts
+++ b/functions/autopilotRedirect.protected.ts
@@ -72,6 +72,8 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
     callback(null, returnObj);
   } catch (err) {
     // If something goes wrong, just handoff to counselor so contact is not lost
+    // eslint-disable-next-line no-console
+    console.error(err);
     callback(null, { actions: [{ redirect: 'task://counselor_handoff' }] });
   }
 };

--- a/functions/createContactlessTask.ts
+++ b/functions/createContactlessTask.ts
@@ -68,6 +68,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(newTask));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/getMessages.ts
+++ b/functions/getMessages.ts
@@ -35,6 +35,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(translation));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/getTranslation.ts
+++ b/functions/getTranslation.ts
@@ -35,6 +35,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(translation));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/healthCheck.ts
+++ b/functions/healthCheck.ts
@@ -22,6 +22,8 @@ export const handler: ServerlessFunctionSignature = async (
   try {
     resolve(success(msg));
   } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
     resolve(error500(err));
   }
 };

--- a/functions/issueSyncToken.ts
+++ b/functions/issueSyncToken.ts
@@ -60,6 +60,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ token: accessToken.toJwt() }));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/listWorkerQueues.ts
+++ b/functions/listWorkerQueues.ts
@@ -39,6 +39,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       return resolve(success({ workerQueues }));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       return resolve(error500(err));
     }
   },

--- a/functions/operatingHours.protected.ts
+++ b/functions/operatingHours.protected.ts
@@ -96,6 +96,8 @@ export const handler = async (
 
     resolve(success('closed'));
   } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
     resolve(error500(err));
   }
 };

--- a/functions/populateCounselors.ts
+++ b/functions/populateCounselors.ts
@@ -73,6 +73,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ workerSummaries }));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/sendSystemMessage.ts
+++ b/functions/sendSystemMessage.ts
@@ -59,6 +59,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success('Message sent'));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/transferChatResolve.ts
+++ b/functions/transferChatResolve.ts
@@ -162,6 +162,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ closed: closedTask.sid, kept: keptTask.sid }));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -260,6 +260,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ taskSid: newTask.sid }));
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
       resolve(error500(err));
     }
   },


### PR DESCRIPTION
This PR adds a `console.error` statement on catch block for every function so we can gather more context and useful information whenever an error occurs, in contrast to the current behavior that's not very helpful.
![Screenshot from 2021-05-24 16-45-34](https://user-images.githubusercontent.com/15805319/119399822-bbbdaa00-bcaf-11eb-8d68-e96a2837d763.png)
![Screenshot from 2021-05-24 16-56-34](https://user-images.githubusercontent.com/15805319/119400860-1d324880-bcb1-11eb-8526-fb483adc812e.png)

The new statement will output something like
![Screenshot from 2021-05-24 16-56-05](https://user-images.githubusercontent.com/15805319/119400887-26bbb080-bcb1-11eb-8b6d-05b1a5c0e681.png)
![Screenshot from 2021-05-24 16-56-20](https://user-images.githubusercontent.com/15805319/119400895-291e0a80-bcb1-11eb-80ea-0eb6aa022966.png)
