### PR TITLE
Change from attribute when creating a new voice task

### DIFF
--- a/functions/voiceWebhook.protected.ts
+++ b/functions/voiceWebhook.protected.ts
@@ -1,0 +1,67 @@
+import '@twilio-labs/serverless-runtime-types';
+import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  success,
+  error400,
+  error500,
+} from '@tech-matters/serverless-helpers';
+
+export type Body = {
+  EventType: string;
+  TaskSid: string;
+  TaskChannelUniqueName: string;
+};
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+};
+
+const TASK_CREATED_EVENT = 'task.created';
+const VOICE_TASK_CHANNEL = 'voice';
+
+export const handler = async (
+  context: Context<EnvVars>,
+  event: Body,
+  callback: ServerlessCallback,
+) => {
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  const { EventType, TaskSid, TaskChannelUniqueName } = event;
+
+  const isNewVoiceTask =
+    EventType === TASK_CREATED_EVENT && TaskChannelUniqueName === VOICE_TASK_CHANNEL;
+
+  if (!isNewVoiceTask) return resolve(success('Is not a new voice task'));
+
+  try {
+    const task = await context
+      .getTwilioClient()
+      .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
+      .tasks(TaskSid)
+      .fetch();
+
+    const taskAttributes = JSON.parse(task.attributes);
+    const { from } = taskAttributes;
+
+    if (!from) {
+      resolve(error400('Missing from attribute'));
+    }
+
+    taskAttributes.from = `${from}_${TaskSid}`;
+
+    const updatedTask = await context
+      .getTwilioClient()
+      .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
+      .tasks(TaskSid)
+      .update({ attributes: JSON.stringify(taskAttributes) });
+
+    return resolve(success(updatedTask));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    return resolve(error500(err));
+  }
+};

--- a/tests/voiceWebhook.test.ts
+++ b/tests/voiceWebhook.test.ts
@@ -1,0 +1,119 @@
+import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { handler as voiceWebhook, Body } from '../functions/voiceWebhook.protected';
+
+import helpers, { MockedResponse } from './helpers';
+
+let tasks: any[] = [
+  {
+    sid: 'task-sid-1',
+    taskChannelUniqueName: 'voice',
+    attributes: '{"from":"+123456"}',
+    fetch: async () => tasks.find(t => t.sid === 'task-sid-1'),
+    update: async ({ attributes }: { attributes: string }) => {
+      const task = tasks.find(t => t.sid === 'task-sid-1');
+      const updatedTask = { ...task, attributes };
+      tasks = tasks.map(t => {
+        if (t.sid === task.sid) {
+          return updatedTask;
+        }
+        return t;
+      });
+
+      return Promise.resolve(updatedTask);
+    },
+  },
+  {
+    sid: 'task-sid-2',
+    taskChannelUniqueName: 'whatsapp',
+    attributes: '{"from":"+999999"}',
+    fetch: async () => tasks.find(t => t.sid === 'task-sid-2'),
+    update: async ({ attributes }: { attributes: string }) => {
+      const task = tasks.find(t => t.sid === 'task-sid-2');
+      const updatedTask = { ...task, attributes };
+      tasks = tasks.map(t => {
+        if (t.sid === task.sid) {
+          return updatedTask;
+        }
+        return t;
+      });
+
+      return Promise.resolve(updatedTask);
+    },
+  },
+];
+
+const workspaces: { [x: string]: any } = {
+  WSxxx: {
+    tasks: (taskSid: string) => {
+      const task = tasks.find(t => t.sid === taskSid);
+      if (task) return task;
+
+      throw new Error(`Task ${taskSid} does not exists`);
+    },
+  },
+};
+
+const baseContext = {
+  getTwilioClient: (): any => ({
+    taskrouter: {
+      workspaces: (workspaceSID: string) => {
+        if (workspaces[workspaceSID]) return workspaces[workspaceSID];
+
+        throw new Error('Workspace does not exists');
+      },
+    },
+  }),
+  DOMAIN_NAME: 'serverless',
+  TWILIO_WORKSPACE_SID: 'WSxxx',
+};
+
+beforeAll(() => {
+  helpers.setup({});
+});
+afterAll(() => {
+  helpers.teardown();
+});
+
+describe('voiceWebhook', () => {
+  test('Should change task.attributes.from when voice channel', async () => {
+    const event: Body = {
+      EventType: 'task.created',
+      TaskSid: 'task-sid-1',
+      TaskChannelUniqueName: 'voice',
+    };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+
+      const response = result as MockedResponse;
+      const updatedTask = response.getBody();
+      const { sid, attributes } = updatedTask;
+      const { from } = JSON.parse(attributes);
+
+      expect(response.getStatus()).toBe(200);
+      expect(sid).toEqual(event.TaskSid);
+      expect(from).toEqual(`+123456_${event.TaskSid}`);
+    };
+
+    await voiceWebhook(baseContext, event, callback);
+  });
+
+  test('Should not change task.attributes.from when not voice channel', async () => {
+    const event: Body = {
+      EventType: 'task.created',
+      TaskSid: 'task-sid-2',
+      TaskChannelUniqueName: 'whatsapp',
+    };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+
+      const response = result as MockedResponse;
+
+      expect(response.getStatus()).toBe(200);
+      expect(response.getBody().toString()).toContain('Is not a new voice task');
+    };
+
+    await voiceWebhook(baseContext, event, callback);
+  });
+});


### PR DESCRIPTION
Every time a task is created, before going directly to Flex, it nows goes through `voiceWebhook` serverless function. If it's not a voice task, nothing is changed. If it's voice, this function will update the task `from` attribute value, making it unique. This is done by appending the `taskSid` onto the `from` attribute value.

**Deployment Plan**
1. Check that Insights behaves as expected;
2. Deploy to all other environments;
3. Setup VoiceWebhook for each account

**How Setup VoiceWebhook for each account?**
1. Deploy `serverless`
2. Copy function URL
![image](https://user-images.githubusercontent.com/1504544/120995116-03970380-c77d-11eb-9f49-de86ffbe99ed.png)
3. Open TaskRouter Settings
![image](https://user-images.githubusercontent.com/1504544/120995466-54a6f780-c77d-11eb-8bd2-6fb282b5e72c.png)
4. Set Event Callback URL to be the function URL, and mark only **Task Created** Event under **Specific Events**
![image](https://user-images.githubusercontent.com/1504544/120995784-a9e30900-c77d-11eb-82fc-7d79a250846c.png)

