### PR TITLE
FlexChannelUpdate false-positive error fix

### DIFF
--- a/functions/webhooks/twitter/FlexChannelUpdate.protected.ts
+++ b/functions/webhooks/twitter/FlexChannelUpdate.protected.ts
@@ -82,7 +82,7 @@ export const handler = async (
       const { status, from } = JSON.parse(channel.attributes);
 
       if (status === 'INACTIVE') {
-        await timeout(3000); // set small timeout just in case some cleanup is still going on
+        await timeout(1000); // set small timeout just in case some cleanup is still going on
 
         const removed = await cleanupUserChannelMap(context, from);
 


### PR DESCRIPTION
This PR fixes an error @Humairaa127 spotted in Zambia. Once a Twitter task is completed, the FlexChannelUpdate webhook might be called several times, but we wan't to cleanup the user-channel map (Sync Document) only once (to avoid generating error logs that are caused because of trying to "delete something that was already deleted").