### PR TITLE
Added addCustomerExternalId

### DIFF
--- a/functions/addCustomerExternalId.protected.ts
+++ b/functions/addCustomerExternalId.protected.ts
@@ -1,0 +1,62 @@
+import '@twilio-labs/serverless-runtime-types';
+import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { responseWithCors, bindResolve, success, error500 } from '@tech-matters/serverless-helpers';
+
+export type Body = {
+  EventType: string;
+  TaskSid: string;
+  TaskChannelUniqueName: string;
+};
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+};
+
+const TASK_CREATED_EVENT = 'task.created';
+
+export const handler = async (
+  context: Context<EnvVars>,
+  event: Body,
+  callback: ServerlessCallback,
+) => {
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  const { EventType, TaskSid } = event;
+
+  const isNewTask = EventType === TASK_CREATED_EVENT;
+
+  if (!isNewTask) {
+    resolve(success(JSON.stringify({ message: 'Is not a new task' })));
+    return;
+  }
+
+  try {
+    const task = await context
+      .getTwilioClient()
+      .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
+      .tasks(TaskSid)
+      .fetch();
+
+    const taskAttributes = JSON.parse(task.attributes);
+    const newAttributes = {
+      ...taskAttributes,
+      customers: {
+        ...taskAttributes.customers,
+        external_id: TaskSid,
+      },
+    };
+
+    const updatedTask = await context
+      .getTwilioClient()
+      .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
+      .tasks(TaskSid)
+      .update({ attributes: JSON.stringify(newAttributes) });
+
+    resolve(success(JSON.stringify(updatedTask)));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    resolve(error500(err));
+  }
+};

--- a/functions/addCustomerExternalId.protected.ts
+++ b/functions/addCustomerExternalId.protected.ts
@@ -39,6 +39,13 @@ export const handler = async (
       .fetch();
 
     const taskAttributes = JSON.parse(task.attributes);
+
+    if (taskAttributes.isContactlessTask) {
+      // this case is already handled when the task is created, in assignOfflineContact function
+      resolve(success(JSON.stringify({ message: 'Is contactless task' })));
+      return;
+    }
+
     const newAttributes = {
       ...taskAttributes,
       customers: {

--- a/functions/addCustomerExternalId.protected.ts
+++ b/functions/addCustomerExternalId.protected.ts
@@ -5,7 +5,6 @@ import { responseWithCors, bindResolve, success, error500 } from '@tech-matters/
 export type Body = {
   EventType: string;
   TaskSid: string;
-  TaskChannelUniqueName: string;
 };
 
 type EnvVars = {

--- a/tests/addCustomerExternalId.test.ts
+++ b/tests/addCustomerExternalId.test.ts
@@ -1,0 +1,132 @@
+import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import {
+  handler as addCustomerExternalId,
+  Body,
+} from '../functions/addCustomerExternalId.protected';
+
+import helpers, { MockedResponse } from './helpers';
+
+let tasks: any[] = [];
+
+const createTask = (sid: string, options: any) => {
+  return {
+    sid,
+    ...options,
+    fetch: async () => tasks.find(t => t.sid === sid),
+    update: async ({ attributes }: { attributes: any }) => {
+      tasks = tasks.map(t => (t.sid === sid ? { ...t, attributes } : t));
+      const task = tasks.find(t => t.sid === sid);
+      return task;
+    },
+  };
+};
+
+const workspaces: { [x: string]: any } = {
+  WSxxx: {
+    tasks: (sid: string) => {
+      if (sid === 'non-existing') throw new Error('Not existing task');
+      return tasks.find(t => t.sid === sid);
+    },
+  },
+};
+
+const baseContext = {
+  getTwilioClient: (): any => ({
+    taskrouter: {
+      workspaces: (workspaceSID: string) => {
+        if (workspaces[workspaceSID]) return workspaces[workspaceSID];
+
+        throw new Error('Workspace does not exists');
+      },
+    },
+  }),
+  DOMAIN_NAME: 'serverless',
+  TWILIO_WORKSPACE_SID: 'WSxxx',
+};
+
+const liveAttributes = { some: 'some', customers: { other: 1 } };
+const offlineAttributes = { some: 'some', isContactlessTask: true };
+
+beforeAll(() => {
+  helpers.setup({});
+  tasks = [
+    ...tasks,
+    createTask('live-contact', { attributes: JSON.stringify(liveAttributes) }),
+    createTask('offline-contact', {
+      attributes: JSON.stringify(offlineAttributes),
+    }),
+  ];
+});
+afterAll(() => {
+  helpers.teardown();
+});
+
+test('Should return status 500', async () => {
+  const event: Body = {
+    EventType: 'task.created',
+    TaskSid: 'non-existing',
+  };
+
+  const callback: ServerlessCallback = (err, result) => {
+    expect(result).toBeDefined();
+    const response = result as MockedResponse;
+    expect(response.getStatus()).toBe(500);
+    expect(response.getBody().toString()).toContain('Not existing task');
+  };
+
+  await addCustomerExternalId(baseContext, event, callback);
+});
+
+test('Should return status 200 (modify live contact)', async () => {
+  const event: Body = {
+    EventType: 'task.created',
+    TaskSid: 'live-contact',
+  };
+
+  const callback: ServerlessCallback = (err, result) => {
+    expect(result).toBeDefined();
+    const response = result as MockedResponse;
+    expect(response.getStatus()).toBe(200);
+    expect(JSON.parse(JSON.parse(response.getBody()).attributes)).toEqual({
+      ...liveAttributes,
+      customers: { ...liveAttributes.customers, external_id: 'live-contact' },
+    });
+  };
+
+  await addCustomerExternalId(baseContext, event, callback);
+});
+
+test('Should return status 200 (ignores offline contact)', async () => {
+  const event: Body = {
+    EventType: 'task.created',
+    TaskSid: 'offline-contact',
+  };
+
+  const callback: ServerlessCallback = (err, result) => {
+    expect(result).toBeDefined();
+    const response = result as MockedResponse;
+    expect(response.getStatus()).toBe(200);
+    expect(JSON.parse(tasks.find(t => t.sid === 'offline-contact').attributes)).toEqual(
+      offlineAttributes,
+    );
+    expect(JSON.parse(response.getBody()).message).toContain('Is contactless task');
+  };
+
+  await addCustomerExternalId(baseContext, event, callback);
+});
+
+test('Should return status 200 (ignores other events)', async () => {
+  const event: Body = {
+    EventType: 'other.event',
+    TaskSid: 'something',
+  };
+
+  const callback: ServerlessCallback = (err, result) => {
+    expect(result).toBeDefined();
+    const response = result as MockedResponse;
+    expect(response.getStatus()).toBe(200);
+    expect(JSON.parse(response.getBody()).message).toContain('Is not a new task');
+  };
+
+  await addCustomerExternalId(baseContext, event, callback);
+});


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-742

This task adds external id into task attributes-> customer object when a new task is created. I've confirmed that the attribute is properly set as soon as the task start existing in Taskrouter, however I have not tested if this fixes the reported Insights bug. The function is deployed in Aselo dev and already linkend so we can test the behavior even before merging the PR (I just don't know how @dee-luo).

To make this work, after the function is deployed in the proper environment, we also need to specify the url as the "Taskrouter callback url", in Twilio console under TaskRouter -> Flex Task Assignment -> Settings -> Event Callbacks.

WIP:
- Unit tests.