### PR TITLE
Post contact survey: proof of concept for chat contacts

### DIFF
--- a/.github/actions/beta-action/action.yml
+++ b/.github/actions/beta-action/action.yml
@@ -1,0 +1,81 @@
+# Install the Twilio CLI and the serverless plugin then deploy the function
+name: 'main-action'
+description: 'Install the Twilio CLI and the serverless plugin then deploy the function'
+inputs:
+  account-sid:
+    description: 'Twilio Account SID'
+    required: true
+  auth-token:
+    description: 'Twilio Token'
+    required: true
+  workspace-sid:  
+      description: 'Twilio Workspace SID'
+      required: true
+  transfer-workflow-sid:  
+    description: 'Chat Transfer Workflow SID'
+    required: true
+  sync-service-api-key:  
+    description: 'Sync Service API Key'
+    required: true
+  sync-service-api-secret:  
+    description: 'Sync Service API Secret'
+    required: true
+  sync-service-sid:
+    description: 'Sync Service SID'
+    required: true
+  chat-service-sid:
+    description: 'Chat Service SID'
+    required: true
+  flex-proxy-service-sid:
+    description: 'Flex Proxy Service SID'
+    required: true
+  operating-info-key:
+    description: 'Operating Info Key'
+    required: true
+  serverless-base-url:
+    description: 'Serverless base url'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # Prepare everything to compile the serverless application with proper env
+    - name: Create environment variable file
+      run: touch .env
+      shell: bash
+    - name: Fill .env
+      run: |
+          cat <<EOT >> .env
+          TWILIO_WORKSPACE_SID=${{ inputs.workspace-sid }}
+          TWILIO_CHAT_TRANSFER_WORKFLOW_SID=${{ inputs.transfer-workflow-sid }}
+          SYNC_SERVICE_API_KEY=${{ inputs.sync-service-api-key }}
+          SYNC_SERVICE_API_SECRET=${{ inputs.sync-service-api-secret }}
+          SYNC_SERVICE_SID=${{ inputs.sync-service-sid }}
+          CHAT_SERVICE_SID=${{ inputs.chat-service-sid }}
+          FLEX_PROXY_SERVICE_SID=${{ inputs.flex-proxy-service-sid }}
+          OPERATING_INFO_KEY=${{ inputs.operating-info-key }}
+          EOT
+      shell: bash
+    # Install dependencies for the twilio functions
+    - name: Install dependencies for the twilio functions
+      run: npm ci
+      shell: bash
+    # Compile typescript to javascript
+    - name: Transpile typescript to javascript
+      run: npx tsc
+      shell: bash
+    # Install Twilio CLI and run deploy command
+    - name: Install Twilio CLI and run deploy command
+      run: npm install twilio-cli -g && twilio plugins:install @twilio-labs/plugin-serverless && twilio serverless:deploy --runtime=node12 --service-name=serverless --environment=dev --force
+      env:
+        TWILIO_ACCOUNT_SID: ${{ inputs.account-sid }}
+        TWILIO_AUTH_TOKEN: ${{ inputs.auth-token }}
+      shell: bash
+    - run: twilio serverless:deploy --runtime=node12 --service-name=serverless --environment=production --force
+      env:
+        TWILIO_ACCOUNT_SID: ${{ inputs.account-sid }}
+        TWILIO_AUTH_TOKEN: ${{ inputs.auth-token }}
+      shell: bash
+    # Check if serverless is up and running
+    - name: Check if serverless is up and running
+      run: curl -f ${{ inputs.serverless-base-url }}/healthCheck
+      shell: bash

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           ssm_parameter: "DEV_TWILIO_AS_CHAT_SERVICE_SID"
           env_variable_name: "CHAT_SERVICE_SID"
+      - name: Set Twilio Flex Proxy service ID
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "DEV_TWILIO_AS_FLEX_PROXY_SERVICE_SID"
+          env_variable_name: "FLEX_PROXY_SERVICE_SID"
       - name: Set Twilio Chat transfer workflow ID
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
@@ -70,8 +75,8 @@ jobs:
           ssm_parameter: "ASELO_DEV_SERVERLESS_BASE_URL"
           env_variable_name: "SERVERLESS_BASE_URL"
       # Call main-action to compile, deploy and check availability
-      - name: Executing main-action
-        uses: ./.github/actions/main-action
+      - name: Executing beta-action
+        uses: ./.github/actions/beta-action
         with:
           account-sid: ${{ secrets.AS_DEV_ACCOUNT_SID }}
           auth-token: ${{ secrets.AS_DEV_AUTH_TOKEN }}
@@ -81,5 +86,6 @@ jobs:
           sync-service-api-secret: $SYNC_SERVICE_API_SECRET
           sync-service-sid: $SYNC_SERVICE_SID
           chat-service-sid: $CHAT_SERVICE_SID
+          flex-proxy-service-sid: $FLEX_PROXY_SERVICE_SID
           operating-info-key: $OPERATING_INFO_KEY
           serverless-base-url: $SERVERLESS_BASE_URL

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -33,7 +33,8 @@ const deleteProxySession = async (
 
     return removed;
   } catch (err) {
-    console.log('deleteProxySession error: ', err);
+    // eslint-disable-next-line no-console
+    console.warn('deleteProxySession error: ', err);
     return false;
   }
 };

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -1,0 +1,108 @@
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+
+export interface Event {
+  Channel: string;
+  CurrentTask: string;
+  Memory: string;
+  UserIdentifier: string;
+}
+
+type EnvVars = {};
+
+const deleteProxySession = async (
+  client: ReturnType<Context['getTwilioClient']>,
+  proxySession: string,
+) => {
+  try {
+    const ps = await client.proxy
+      .services('KSe0886a03f78ebc55178f3996591dfd0b') // TODO: move sid to env vars (edit deploy scripts needed)
+      .sessions(proxySession)
+      .fetch();
+
+    if (!ps) {
+      // eslint-disable-next-line no-console
+      console.warn(`Tried to remove proxy session ${proxySession} but couldn't find it.`);
+      return false;
+    }
+
+    const removed = await ps.remove();
+
+    return removed;
+  } catch (err) {
+    console.log('deleteProxySession error: ', err);
+    return false;
+  }
+};
+
+const deactivateChannel = async (
+  client: ReturnType<Context['getTwilioClient']>,
+  ServiceSid: string,
+  ChannelSid: string,
+) => {
+  const channel = await client.chat
+    .services(ServiceSid)
+    .channels(ChannelSid)
+    .fetch();
+
+  const attributes = JSON.parse(channel.attributes);
+  const newAttributes = { ...attributes, status: 'INACTIVE' };
+
+  const updated = await channel.update({
+    attributes: JSON.stringify(newAttributes),
+    xTwilioWebhookEnabled: 'true',
+  });
+
+  if (attributes.proxySession) {
+    await deleteProxySession(client, attributes.proxySession);
+  }
+
+  return updated;
+};
+
+export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
+  context: Context<EnvVars>,
+  event: Event,
+  callback: ServerlessCallback,
+) => {
+  Object.entries(event).forEach(([k, v]) => {
+    console.log(k, JSON.stringify(v));
+  });
+  try {
+    const memory = JSON.parse(event.Memory);
+    const { ServiceSid, ChannelSid } = memory.twilio.chat;
+
+    const client = context.getTwilioClient();
+
+    if (event.Channel === 'chat' && event.CurrentTask === 'complete_post_survey') {
+      const ws = await client.chat
+        .services(ServiceSid)
+        .channels(ChannelSid)
+        .webhooks.list();
+
+      await Promise.all(ws.map(w => w.remove())); // Remove the bot from the channel
+
+      await client.chat
+        .services(ServiceSid)
+        .channels(ChannelSid)
+        .messages.create({
+          body: 'Thanks!!',
+          xTwilioWebhookEnabled: 'true',
+        });
+
+      await deactivateChannel(client, ServiceSid, ChannelSid);
+    }
+
+    const actions: never[] = []; // Empty actions array so bot finishes it's execution
+    const returnObj = { actions };
+
+    callback(null, returnObj);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    callback(null, { actions: [] });
+  }
+};

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -1,0 +1,72 @@
+import '@twilio-labs/serverless-runtime-types';
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  error400,
+  error500,
+  success,
+} from '@tech-matters/serverless-helpers';
+
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+type EnvVars = {
+  CHAT_SERVICE_SID: string;
+};
+
+export type Body = {
+  channelSid?: string;
+};
+
+const triggerPostSurveyFlow = async (context: Context<EnvVars>, channelSid: string) => {
+  const client = context.getTwilioClient();
+
+  await client.chat
+    .services(context.CHAT_SERVICE_SID)
+    .channels(channelSid)
+    .webhooks.create({
+      type: 'webhook',
+      configuration: {
+        filters: ['onMessageSent'],
+        method: 'POST',
+        url:
+          'https://channels.autopilot.twilio.com/v1/ACd8a2e89748318adf6ddff7df6948deaf/UA59f7eb8ec74c4a18b229f7d6ff5a63ab/twilio-chat', // TODO: move url to env vars (edit deploy scripts needed)
+      },
+    });
+
+  const messageResult = await context
+    .getTwilioClient()
+    .chat.services(context.CHAT_SERVICE_SID)
+    .channels(channelSid)
+    .messages.create({
+      body: 'Hey! Before you leave, can you answer a few questions about this contact?',
+      xTwilioWebhookEnabled: 'true',
+    });
+
+  return messageResult;
+};
+
+export const handler: ServerlessFunctionSignature = TokenValidator(
+  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+
+    const { channelSid } = event;
+
+    try {
+      if (channelSid === undefined) return resolve(error400('channelSid'));
+
+      await triggerPostSurveyFlow(context, channelSid);
+
+      return resolve(success(JSON.stringify({ message: 'Post survey init OK!' })));
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      return resolve(error500(err));
+    }
+  },
+);


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-771
This PR is related to https://github.com/techmatters/flex-plugins/pull/490.

This PR adds two functions to work trigger a post contact survey:
- `postSurveyInit` which adds a new webhook to the chat channel pointing to a chat bot and triggers it by sending a message.
- `postSurveyComplete` that removes the above bot and mimic the behavior of the channel janitor.