### PR TITLE
Move the remaining service SIDs to the env vars (deployment scripts)

### DIFF
--- a/.github/actions/beta-action/action.yml
+++ b/.github/actions/beta-action/action.yml
@@ -35,8 +35,8 @@ inputs:
   flex-proxy-service-sid:
     description: 'Flex Proxy Service SID'
     required: true
-  system-secret:
-    description: 'Secret to make HRM system calls'
+  hrm-static-key:
+    description: 'HRM static key to make HRM calls'
     required: true
   survey-workflow-sid:
     description: 'Survey Workflow SID'
@@ -62,7 +62,7 @@ runs:
           CHAT_SERVICE_SID=${{ inputs.chat-service-sid }}
           OPERATING_INFO_KEY=${{ inputs.operating-info-key }}
           FLEX_PROXY_SERVICE_SID=${{ inputs.flex-proxy-service-sid }}
-          SYSTEM_SECRET=${{ inputs.system-secret }}
+          HRM_STATIC_KEY=${{ inputs.hrm-static-key }}
           SURVEY_WORKFLOW_SID=${{ inputs.survey-workflow-sid }}
           POST_SURVEY_BOT_CHAT_URL=${{ inputs.post-survey-bot-chat-url }}
           EOT

--- a/.github/actions/beta-action/action.yml
+++ b/.github/actions/beta-action/action.yml
@@ -26,14 +26,23 @@ inputs:
   chat-service-sid:
     description: 'Chat Service SID'
     required: true
-  flex-proxy-service-sid:
-    description: 'Flex Proxy Service SID'
-    required: true
   operating-info-key:
     description: 'Operating Info Key'
     required: true
   serverless-base-url:
     description: 'Serverless base url'
+    required: true
+  flex-proxy-service-sid:
+    description: 'Flex Proxy Service SID'
+    required: true
+  system-secret:
+    description: 'Secret to make HRM system calls'
+    required: true
+  survey-workflow-sid:
+    description: 'Survey Workflow SID'
+    required: true
+  post-survey-bot-chat-url:
+    description: 'Post Survey Bot Programmable Chat URL'
     required: true
 runs:
   using: "composite"
@@ -51,8 +60,11 @@ runs:
           SYNC_SERVICE_API_SECRET=${{ inputs.sync-service-api-secret }}
           SYNC_SERVICE_SID=${{ inputs.sync-service-sid }}
           CHAT_SERVICE_SID=${{ inputs.chat-service-sid }}
-          FLEX_PROXY_SERVICE_SID=${{ inputs.flex-proxy-service-sid }}
           OPERATING_INFO_KEY=${{ inputs.operating-info-key }}
+          FLEX_PROXY_SERVICE_SID=${{ inputs.flex-proxy-service-sid }}
+          SYSTEM_SECRET=${{ inputs.system-secret }}
+          SURVEY_WORKFLOW_SID=${{ inputs.survey-workflow-sid }}
+          POST_SURVEY_BOT_CHAT_URL=${{ inputs.post-survey-bot-chat-url }}
           EOT
       shell: bash
     # Install dependencies for the twilio functions

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -74,11 +74,11 @@ jobs:
         with:
           ssm_parameter: "DEV_TWILIO_AS_FLEX_PROXY_SERVICE_SID"
           env_variable_name: "FLEX_PROXY_SERVICE_SID"
-      - name: Set System Secret to make HRM system calls
+      - name: Set HRM static key to make HRM calls
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
-          ssm_parameter: "DEV_TWILIO_AS_SYSTEM_SECRET"
-          env_variable_name: "SYSTEM_SECRET"
+          ssm_parameter: "DEV_TWILIO_AS_HRM_STATIC_KEY"
+          env_variable_name: "HRM_STATIC_KEY"
       - name: Set Survey Workflow SID
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
@@ -104,6 +104,6 @@ jobs:
           operating-info-key: $OPERATING_INFO_KEY
           serverless-base-url: $SERVERLESS_BASE_URL
           flex-proxy-service-sid: $FLEX_PROXY_SERVICE_SID
-          system-secret: $SYSTEM_SECRET
+          hrm-static-key: $HRM_STATIC_KEY
           survey-workflow-sid: $SURVEY_WORKFLOW_SID
           post-survey-bot-chat-url: $POST_SURVEY_BOT_CHAT_URL

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -39,11 +39,6 @@ jobs:
         with:
           ssm_parameter: "DEV_TWILIO_AS_CHAT_SERVICE_SID"
           env_variable_name: "CHAT_SERVICE_SID"
-      - name: Set Twilio Flex Proxy service ID
-        uses: "marvinpinto/action-inject-ssm-secrets@latest"
-        with:
-          ssm_parameter: "DEV_TWILIO_AS_FLEX_PROXY_SERVICE_SID"
-          env_variable_name: "FLEX_PROXY_SERVICE_SID"
       - name: Set Twilio Chat transfer workflow ID
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
@@ -72,8 +67,28 @@ jobs:
       - name: Set serverless base URL
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
-          ssm_parameter: "ASELO_DEV_SERVERLESS_BASE_URL"
+          ssm_parameter: "DEV_TWILIO_AS_SERVERLESS_BASE_URL"
           env_variable_name: "SERVERLESS_BASE_URL"
+      - name: Set Twilio Flex Proxy service ID
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "DEV_TWILIO_AS_FLEX_PROXY_SERVICE_SID"
+          env_variable_name: "FLEX_PROXY_SERVICE_SID"
+      - name: Set System Secret to make HRM system calls
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "DEV_TWILIO_AS_SYSTEM_SECRET"
+          env_variable_name: "SYSTEM_SECRET"
+      - name: Set Survey Workflow SID
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "DEV_TWILIO_AS_SURVEY_WORKFLOW_SID"
+          env_variable_name: "SURVEY_WORKFLOW_SID"
+      - name: Set Post Survey Bot Programmable Chat URL
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "DEV_TWILIO_AS_POST_SURVEY_BOT_CHAT_URL"
+          env_variable_name: "POST_SURVEY_BOT_CHAT_URL"
       # Call main-action to compile, deploy and check availability
       - name: Executing beta-action
         uses: ./.github/actions/beta-action
@@ -86,6 +101,9 @@ jobs:
           sync-service-api-secret: $SYNC_SERVICE_API_SECRET
           sync-service-sid: $SYNC_SERVICE_SID
           chat-service-sid: $CHAT_SERVICE_SID
-          flex-proxy-service-sid: $FLEX_PROXY_SERVICE_SID
           operating-info-key: $OPERATING_INFO_KEY
           serverless-base-url: $SERVERLESS_BASE_URL
+          flex-proxy-service-sid: $FLEX_PROXY_SERVICE_SID
+          system-secret: $SYSTEM_SECRET
+          survey-workflow-sid: $SURVEY_WORKFLOW_SID
+          post-survey-bot-chat-url: $POST_SURVEY_BOT_CHAT_URL

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -33,7 +33,7 @@ export interface Event {
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;
-  SYSTEM_SECRET: string;
+  HRM_STATIC_KEY: string;
 };
 
 const saveSurveyInInsights = async (postSurveyConfigJson: OneToManyConfigSpecs, memory: BotMemory, surveyTask: TaskInstance) => {
@@ -48,7 +48,7 @@ const saveSurveyInInsights = async (postSurveyConfigJson: OneToManyConfigSpecs, 
   await surveyTask.update({ attributes: JSON.stringify(finalAttributes) });
 };
 
-const saveSurveyInHRM = async (postSurveyConfigJson: OneToManyConfigSpecs, memory: BotMemory, surveyTask: TaskInstance, hrmBaseUrl: string, systemSecret: string) => {
+const saveSurveyInHRM = async (postSurveyConfigJson: OneToManyConfigSpecs, memory: BotMemory, surveyTask: TaskInstance, hrmBaseUrl: string, hrmStaticKey: string) => {
   const handlerPath = Runtime.getFunctions()['helpers/hrmService'].path;
   const buildDataObject = require(handlerPath)
     .buildDataObject as BuildDataObject;
@@ -69,7 +69,7 @@ const saveSurveyInHRM = async (postSurveyConfigJson: OneToManyConfigSpecs, memor
     data: JSON.stringify(body),
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Basic ${systemSecret}`
+      'Authorization': `Basic ${hrmStaticKey}`
     },
   });
 };
@@ -115,7 +115,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
           // parallel execution to save survey collected data in insights and hrm
           await Promise.all([
             saveSurveyInInsights(postSurveyConfigSpecs, memory, surveyTask),
-            saveSurveyInHRM(postSurveyConfigSpecs, memory, surveyTask, hrmBaseUrl, context.SYSTEM_SECRET),
+            saveSurveyInHRM(postSurveyConfigSpecs, memory, surveyTask, hrmBaseUrl, context.HRM_STATIC_KEY),
           ]);
         } else {
         // eslint-disable-next-line no-console

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -17,6 +17,8 @@ const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 type EnvVars = {
   CHAT_SERVICE_SID: string;
   TWILIO_WORKSPACE_SID: string;
+  SURVEY_WORKFLOW_SID: string;
+  POST_SURVEY_BOT_CHAT_URL: string;
 };
 
 export type Body = {
@@ -36,7 +38,7 @@ const createSurveyTask = async (context: Context<EnvVars>, event: Required<Body>
   };
 
   const surveyTask = await client.taskrouter.workspaces(context.TWILIO_WORKSPACE_SID).tasks.create({
-    workflowSid: 'WW6a967d8f663083bdb8ae586539fa71d7', // TODO: move this out
+    workflowSid: context.SURVEY_WORKFLOW_SID,
     taskChannel: 'survey',
     attributes: JSON.stringify(taskAttributes),
     timeout: 30,
@@ -69,8 +71,7 @@ const triggerPostSurveyFlow = async (context: Context<EnvVars>, channelSid: stri
       configuration: {
         filters: ['onMessageSent'],
         method: 'POST',
-        url:
-          'https://channels.autopilot.twilio.com/v1/ACd8a2e89748318adf6ddff7df6948deaf/UAb5360da99806f414522ab636fe3c5a17/twilio-chat', // TODO: move url to env vars (edit deploy scripts needed)
+        url: context.POST_SURVEY_BOT_CHAT_URL,
       },
     });
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-788

This PR is about cleaning the hardcoded resources that will change from one account to another. They are added to the "beta deployment script" in order to preserve the deployments to other environments without breaking them. 

As an important note, even if this is preserving the deployment script untouched, there are still breaking changes regarding the Taskrouter Event Callback introduced in https://github.com/techmatters/serverless/pull/90.