### PR TITLE
Intentionally break healthCheck

### DIFF
--- a/.github/actions/healthCheck/index.js
+++ b/.github/actions/healthCheck/index.js
@@ -19,7 +19,7 @@ async function healthCheck () {
     const service = await client.serverless.services('serverless').fetch();
     const productionEnv = (await service.environments().list()).find(e => e.domainSuffix === 'production');
   
-    const url = `https://${productionEnv.domainName}/healthCheck`;
+    const url = `https://${productionEnv.domainName}/healthCheckasdasd`;
   
     console.log('Attempting health check against ', url);
     const response = await fetch(url);


### PR DESCRIPTION
This PR intentionally breaks https://github.com/techmatters/serverless/pull/102 to test if the workflow fails if health check fails. It will be reverted the tests.