### PR TITLE
Added env vars required for case document feature

### DIFF
--- a/.github/actions/deploy-beta/action.yml
+++ b/.github/actions/deploy-beta/action.yml
@@ -41,6 +41,18 @@ inputs:
   post-survey-bot-chat-url:
     description: 'Post Survey Bot Programmable Chat URL'
     required: true
+  aselo-app-access-key:
+    description: 'AWS credentials for Aselo user'
+    required: true
+  aselo-app-secret-key:
+    description: 'AWS credentials for Aselo user'
+    required: true
+  aws-region:
+    description: 'AWS region where Aselo documents bucket is hosted'
+    required: true
+  s3-bucket:
+    description: 'S3 bucket name where Aselo documents are stored'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -62,6 +74,10 @@ runs:
           HRM_STATIC_KEY=${{ inputs.hrm-static-key }}
           SURVEY_WORKFLOW_SID=${{ inputs.survey-workflow-sid }}
           POST_SURVEY_BOT_CHAT_URL=${{ inputs.post-survey-bot-chat-url }}
+          ASELO_APP_ACCESS_KEY=${{ inputs.aselo-app-access-key }}
+          ASELO_APP_SECRET_KEY=${{ inputs.aselo-app-secret-key }}
+          S3_BUCKET=${{ inputs.aws-region }}
+          AWS_REGION=${{ inputs.s3-bucket }}
           EOT
       shell: bash
     # Install dependencies for the twilio functions

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -84,6 +84,26 @@ jobs:
         with:
           ssm_parameter: "DEV_TWILIO_AS_POST_SURVEY_BOT_CHAT_URL"
           env_variable_name: "POST_SURVEY_BOT_CHAT_URL"
+      - name: Set AWS credentials for Aselo user
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "ASELO_APP_ACCESS_KEY"
+          env_variable_name: "ASELO_APP_ACCESS_KEY"
+      - name: Set AWS credentials for Aselo user
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "ASELO_APP_SECRET_KEY"
+          env_variable_name: "ASELO_APP_SECRET_KEY"
+      - name: AWS region where Aselo documents bucket is hosted
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "REGION"
+          env_variable_name: "AWS_REGION"
+      - name: Set S3 bucket name where Aselo documents are stored
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "DEV_TWILIO_AS_S3_BUCKET_DOCS"
+          env_variable_name: "S3_BUCKET"
       # Call deploy-beta to compile and deploy
       - name: Executing deploy-beta
         uses: ./.github/actions/deploy-beta
@@ -101,3 +121,7 @@ jobs:
           hrm-static-key: $HRM_STATIC_KEY
           survey-workflow-sid: $SURVEY_WORKFLOW_SID
           post-survey-bot-chat-url: $POST_SURVEY_BOT_CHAT_URL
+          aselo-app-access-key: $ASELO_APP_ACCESS_KEY
+          aselo-app-secret-key: $ASELO_APP_SECRET_KEY
+          aws-region: $AWS_REGION
+          s3-bucket: $S3_BUCKET


### PR DESCRIPTION
This PR adds the required env vars needed for case document to the deploy scripts of Aselo Dev.

Notes:
- We already have `secrets.AWS_DEFAULT_REGION` in GH secrets, do you think is really necessary to have `REGION` in Parameter Store?
- Same question goes for the AWS Aselo user's credentials, they could be hosted in GH secrets, but that will continue to split our sources of truth.
- I'm merging this PR to test it, but feel free to leave comments so I can address them.