### PR TITLE
Implement saveContactToSaferNet function

### DIFF
--- a/functions/saveContactToSaferNet.ts
+++ b/functions/saveContactToSaferNet.ts
@@ -1,0 +1,65 @@
+import '@twilio-labs/serverless-runtime-types';
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+import { responseWithCors, bindResolve, error500, success } from '@tech-matters/serverless-helpers';
+import axios from 'axios';
+import crypto from 'crypto';
+
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+export type Body = {
+  payload: string;
+};
+
+type EnvVars = {
+  SAFERNET_ENDPOINT: string;
+  SAFERNET_TOKEN: string;
+};
+
+export const handler: ServerlessFunctionSignature = TokenValidator(
+  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+
+    try {
+      const { SAFERNET_ENDPOINT, SAFERNET_TOKEN } = context;
+
+      if (!SAFERNET_ENDPOINT) throw new Error('SAFERNET_ENDPOINT env var not provided.');
+      if (!SAFERNET_TOKEN) throw new Error('SAFERNET_TOKEN env var not provided.');
+
+      const { payload } = event;
+
+      const signedPayload = crypto
+        .createHmac('sha256', SAFERNET_TOKEN)
+        .update(payload)
+        .digest('hex');
+
+      const saferNetResponse = await axios({
+        url: SAFERNET_ENDPOINT,
+        method: 'POST',
+        data: payload,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Signature': `sha256=${signedPayload}`,
+        },
+      });
+
+      if (saferNetResponse.data.success) {
+        resolve(success(saferNetResponse.data.post_survey_link));
+      } else {
+        const errorMessage = saferNetResponse.data.error_message;
+
+        // eslint-disable-next-line no-console
+        console.error(errorMessage);
+        resolve(error500(errorMessage));
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      resolve(error500(err));
+    }
+  },
+);


### PR DESCRIPTION
PRs: [CHI-847](https://bugs.benetech.org/browse/CHI-847), [CHI-850](https://bugs.benetech.org/browse/CHI-850), [CHI-848](https://bugs.benetech.org/browse/CHI-848)
Primary reviewer: @GPaoloni 

This PR introduces 2 new env vars (just for SaferNet environments):
- SAFERNET_ENDPOINT
- SAFERNET_TOKEN

Right now I'm setting them directly on Twilio Console. We may think later on how to automate these env vars that are specific to a helpline.