### PR TITLE
Fixed if condition by using format function

### DIFF
--- a/.github/actions/custom-actions/action.yml
+++ b/.github/actions/custom-actions/action.yml
@@ -3,5 +3,5 @@ runs:
   using: "composite"
   steps:
     - name: Aselo Development release custom action
-      if: ${{ github.workflow }} == 'Aselo Development release'
+      if: github.workflow == format('Aselo Development release')
       uses: ./.github/actions/custom-actions/aselo_development_custom


### PR DESCRIPTION
This PR fixes an existing issue in https://github.com/techmatters/serverless/pull/158, where the `if` condition always evaluates to true and hence all custom actions are run.

See https://github.com/actions/runner/issues/1173#issuecomment-950153393

Code tested in https://github.com/techmatters/serverless/pull/164