### PR TITLE
Enables post survey initial message to be translated

### DIFF
--- a/assets/translations/pt-BR/postSurveyMessages.private.json
+++ b/assets/translations/pt-BR/postSurveyMessages.private.json
@@ -1,0 +1,3 @@
+{
+  "triggerMessage": "Ei! Antes de sair, você pode responder a algumas perguntas sobre esse contato?"
+}

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -128,6 +128,8 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
       if (channelSid === undefined) return resolve(error400('channelSid'));
       if (taskSid === undefined) return resolve(error400('taskSid'));
 
+      const triggerMessage = getTriggerMessage(event);
+
       await createSurveyTask(context, { channelSid, taskSid });
       await triggerPostSurveyFlow(context, channelSid, triggerMessage);
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-829
This PR is related to https://github.com/techmatters/flex-plugins/pull/557

This PR:
- Adds `pt-BR` file for post survey translations. I think we will eventually add more messages to this, that's why I've created an isolated file, let me know if you prefer to have it merged with the already existing `messages.private.json` one.
- `postSurveyInit` will try to translate the initial message if there's a `taskLanguage` parameter being sent to the request.