### PR TITLE
Change available check in assignOfflineContact

### DIFF
--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -98,7 +98,7 @@ const assignToOfflineWorker = async (
   const availableActivity = await context
     .getTwilioClient()
     .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
-    .activities.list({ friendlyName: 'Available' });
+    .activities.list({ available: 'true' });
 
   await targetWorker.update({
     activitySid: availableActivity[0].sid,

--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -99,9 +99,12 @@ const assignToOfflineWorker = async (
     .getTwilioClient()
     .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
     .activities.list({ available: 'true' });
-if (availableActivity.length > 1) {
-  console.warn(`There are ${availabilityActivity.length} available worker activities, but there should only be one.`);
-}
+
+  if (availableActivity.length > 1) {
+    // eslint-disable-next-line no-console
+    console.warn(`There are ${availableActivity.length} available worker activities, but there should only be one.`);
+  }
+
   await targetWorker.update({
     activitySid: availableActivity[0].sid,
     attributes: JSON.stringify({ ...previousAttributes, waitingOfflineContact: true }), // waitingOfflineContact is used to avoid other tasks to be assigned during this window of time (workflow rules)

--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -99,7 +99,9 @@ const assignToOfflineWorker = async (
     .getTwilioClient()
     .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
     .activities.list({ available: 'true' });
-
+if (availableActivity.length > 1) {
+  console.warn(`There are ${availabilityActivity.length} available worker activities, but there should only be one.`);
+}
   await targetWorker.update({
     activitySid: availableActivity[0].sid,
     attributes: JSON.stringify({ ...previousAttributes, waitingOfflineContact: true }), // waitingOfflineContact is used to avoid other tasks to be assigned during this window of time (workflow rules)

--- a/tests/assignOfflineContact.test.ts
+++ b/tests/assignOfflineContact.test.ts
@@ -108,6 +108,7 @@ const workspaces: { [x: string]: any } = {
         {
           sid: 'Available',
           friendlyName: 'Available',
+          available: 'true',
         },
       ],
     },


### PR DESCRIPTION
This PR fixes a potential bug when assigning an offline contact. Previously we looked for an available activity using the `friendlyName`, but now that we have helplines with different languages this might change, so the check is now changed to use the `available` property of the activities.
Primary reviewer: @murilovmachado  

[:negative_squared_cross_mark:  ] Corresponding issue has been opened
[:heavy_check_mark: ] ~New tests added~ Tests matches this change

### Verification steps
- Start a local server with `npm run start`
- Expose the local server to the internet (using ngrok that can be done with `ngrok http <port>`, this requires configuring ngrok authtoken, you can obtain that login into https://dashboard.ngrok.com/get-started/setup).
- From Flex, change the Serverless url like `Twilio.Flex.Manager.getInstance().serviceConfiguration.attributes.serverless_base_url = '<your local server url>'`
- Submit an offline contact while being offline.