### PR TITLE
Encode payload before signing it

### DIFF
--- a/functions/saveContactToSaferNet.ts
+++ b/functions/saveContactToSaferNet.ts
@@ -34,13 +34,13 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       const signedPayload = crypto
         .createHmac('sha256', SAFERNET_TOKEN)
-        .update(payload)
+        .update(encodeURIComponent(payload))
         .digest('hex');
 
       const saferNetResponse = await axios({
         url: SAFERNET_ENDPOINT,
         method: 'POST',
-        data: payload,
+        data: JSON.parse(payload),
         headers: {
           'Content-Type': 'application/json',
           'X-Signature': `sha256=${signedPayload}`,


### PR DESCRIPTION
## Description
Jira ticket: https://bugs.benetech.org/browse/CHI-924
Primary reviewer: @nickhurlburt 

This PR encodes the payload before generating the signature.
This solution was discussed with Caio from SaferNet and it fixes the issue we were getting with accents in the payload.

Note that we're only encoding the payload for creating the signature, not the body of the POST.
