### PR TITLE
Replaced deploy-beta to main-action in deploy workflows

### DIFF
--- a/.github/workflows/aarambh_production.yml
+++ b/.github/workflows/aarambh_production.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_IN_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.IN_PROD_ACCOUNT_SID }}
           auth-token: ${{ secrets.IN_PROD_AUTH_TOKEN }}

--- a/.github/workflows/aarambh_staging.yml
+++ b/.github/workflows/aarambh_staging.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_IN_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.IN_STG_ACCOUNT_SID }}
           auth-token: ${{ secrets.IN_STG_AUTH_TOKEN }}

--- a/.github/workflows/aselo_beta.yml
+++ b/.github/workflows/aselo_beta.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_AS_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.AS_STG_ACCOUNT_SID }}
           auth-token: ${{ secrets.AS_STG_AUTH_TOKEN }}

--- a/.github/workflows/ethiopia_production.yml
+++ b/.github/workflows/ethiopia_production.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_ET_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.ET_PROD_ACCOUNT_SID }}
           auth-token: ${{ secrets.ET_PROD_AUTH_TOKEN }}

--- a/.github/workflows/ethiopia_staging.yml
+++ b/.github/workflows/ethiopia_staging.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_ET_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.ET_STG_ACCOUNT_SID }}
           auth-token: ${{ secrets.ET_STG_AUTH_TOKEN }}

--- a/.github/workflows/malawi_production.yml
+++ b/.github/workflows/malawi_production.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_MW_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.MW_PROD_ACCOUNT_SID }}
           auth-token: ${{ secrets.MW_PROD_AUTH_TOKEN }}

--- a/.github/workflows/malawi_staging.yml
+++ b/.github/workflows/malawi_staging.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_MW_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.MW_STG_ACCOUNT_SID }}
           auth-token: ${{ secrets.MW_STG_AUTH_TOKEN }}

--- a/.github/workflows/south_africa_production.yml
+++ b/.github/workflows/south_africa_production.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_ZA_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.ZA_PROD_ACCOUNT_SID }}
           auth-token: ${{ secrets.ZA_PROD_AUTH_TOKEN }}

--- a/.github/workflows/south_africa_staging.yml
+++ b/.github/workflows/south_africa_staging.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_ZA_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.ZA_STG_ACCOUNT_SID }}
           auth-token: ${{ secrets.ZA_STG_AUTH_TOKEN }}

--- a/.github/workflows/zambia_production.yml
+++ b/.github/workflows/zambia_production.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_ZM_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.ZM_PROD_ACCOUNT_SID }}
           auth-token: ${{ secrets.ZM_PROD_AUTH_TOKEN }}

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_ZM_S3_BUCKET_DOCS"
           env_variable_name: "S3_BUCKET"
-      # Call deploy-beta to compile and deploy
-      - name: Executing deploy-beta
-        uses: ./.github/actions/deploy-beta
+      # Call main-action to compile and deploy
+      - name: Executing main-action
+        uses: ./.github/actions/main-action
         with:
           account-sid: ${{ secrets.ZM_STG_ACCOUNT_SID }}
           auth-token: ${{ secrets.ZM_STG_AUTH_TOKEN }}


### PR DESCRIPTION
## Description
This PR moves the remaining deploy workflows from deploy-beta to use main-action instead. This means that the custom actions process is incorporated, but not running any extra step since there aren't any defined for this workflows (yet).

### Checklist
- [x] Corresponding issue has been opened https://bugs.benetech.org/browse/CHI-966
- [ ] N/A New tests added
- [ ] N/A Strings are localized