### PR TITLE
[PoC] First implementation Worker Availability

### DIFF
--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -107,7 +107,7 @@ const assignToOfflineWorker = async (
 
   await targetWorker.update({
     activitySid: availableActivity[0].sid,
-    attributes: JSON.stringify({ ...previousAttributes, waitingOfflineContact: true }), // waitingOfflineContact is used to avoid other tasks to be assigned during this window of time (workflow rules)
+    attributes: JSON.stringify({ ...previousAttributes, waitingOfflineContact: true, keepAvailable: true }), // waitingOfflineContact is used to avoid other tasks to be assigned during this window of time (workflow rules), keepAvailable is used to prevent custom worker status handler to set offline the worker during this interval
   });
 
   const result = await assignToAvailableWorker(event, newTask);


### PR DESCRIPTION
## Description
This PR is a complementary piece to https://github.com/techmatters/flex-plugins/pull/597.
- Sets to true `keepAvailable` when assigning offline contacts to Offline workers.

[WIP]
- Do the same for transfers once we have a clearer idea on how to handle this (ongoing conversation).

### Verification steps
This is deployed to the `dev` environment, so just changing the `serverlessBaseUrl` and test from the frontend is the easiest. This can be done by pasting in the Chrome Console:
`Twilio.Flex.Manager.getInstance().serviceConfiguration.attributes.serverless_base_url = "https://serverless-9971-dev.twil.io"`