### PR TITLE
Added support for Live_Report and Reporter_Country_ID from env vars

### DIFF
--- a/.github/actions/custom-actions/aselo_development_custom/action.yml
+++ b/.github/actions/custom-actions/aselo_development_custom/action.yml
@@ -18,6 +18,16 @@ runs:
       with:
         ssm_parameter: "IWF_API_URL"
         env_variable_name: "IWF_API_URL"
+    # - name: Set IWF_API_ENVIRONMENT
+    #   uses: "marvinpinto/action-inject-ssm-secrets@latest"
+    #   with:
+    #     ssm_parameter: "DEV_AS_IWF_API_ENVIRONMENT"
+    #     env_variable_name: "IWF_API_ENVIRONMENT"
+    # - name: Set IWF_API_COUNTRY_CODE
+    #   uses: "marvinpinto/action-inject-ssm-secrets@latest"
+    #   with:
+    #     ssm_parameter: "DEV_AS_IWF_API_COUNTRY_CODE"
+    #     env_variable_name: "IWF_API_COUNTRY_CODE"
     # Append environment variables
     - name: Add IWF_API_USERNAME
       run: echo "IWF_API_USERNAME=${{ env.IWF_API_USERNAME }}" >> .env
@@ -28,4 +38,10 @@ runs:
     - name: Add IWF_API_URL
       run: echo "IWF_API_URL=${{ env.IWF_API_URL }}" >> .env
       shell: bash
+    # - name: Add IWF_API_ENVIRONMENT
+    #   run: echo "IWF_API_ENVIRONMENT=${{ env.IWF_API_ENVIRONMENT }}" >> .env
+    #   shell: bash
+    # - name: Add IWF_API_COUNTRY_CODE
+    #   run: echo "IWF_API_COUNTRY_CODE=${{ env.IWF_API_COUNTRY_CODE }}" >> .env
+    #   shell: bash
     

--- a/functions/reportToIWF.ts
+++ b/functions/reportToIWF.ts
@@ -19,6 +19,8 @@ type EnvVars = {
   IWF_API_USERNAME: string;
   IWF_API_PASSWORD: string;
   IWF_API_URL: string;
+  IWF_API_ENVIRONMENT?: string;
+  IWF_API_COUNTRY_CODE?: string;
 };
 
 type IWFReportPayload = {
@@ -65,9 +67,14 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = TokenValidat
       if (!Reporter_Anonymous || (Reporter_Anonymous !== 'Y' && Reporter_Anonymous !== 'N'))
         return resolve(error400('Reporter_Anonymous'));
 
+      const liveReportFlag = context.IWF_API_ENVIRONMENT === 'L' ? 'L' : 'T';
+      const countryID = context.IWF_API_COUNTRY_CODE
+        ? parseInt(context.IWF_API_COUNTRY_CODE, 10)
+        : null;
+
       const body: IWFReportPayload = {
         Reporting_Type: 'R',
-        Live_Report: 'T', // This will change when we go live
+        Live_Report: liveReportFlag,
         Media_Type_ID: 1,
         Report_Channel_ID: 51,
         Origin_ID: 5,
@@ -79,7 +86,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = TokenValidat
         Reporter_Last_Name: Reporter_Last_Name || null,
         Reporter_Email_ID: Reporter_Email_ID || null,
         Reporter_Description: Reporter_Description || null,
-        Reporter_Country_ID: null,
+        Reporter_Country_ID: countryID,
       };
 
       const hash = Buffer.from(`${context.IWF_API_USERNAME}:${context.IWF_API_PASSWORD}`).toString(


### PR DESCRIPTION
## Description
This PR adds options to provide "live" flag (to report "in production mode") and country id to the reports to IWF. This are optional environment variables in the Serverless instance, and if not provided, we'll just use `'T'` (test) flag and `null` country id.
This env vars should be added in the same custom action as the IWF credentials. Examples can be seen in the Aselo Development custom action (the code is commented out tho).

Instructions for the future selves can be found in https://benetech.app.box.com/notes/911942535061.