### PR TITLE
Post survey fixes to avoid double greeting message

### DIFF
--- a/assets/formDefinitions/v1/insights/postSurvey.private.json
+++ b/assets/formDefinitions/v1/insights/postSurvey.private.json
@@ -1,12 +1,12 @@
 [
   {
-    "insightsObject": "customers",
-    "attributeName": "customer_attribute_9",
+    "insightsObject": "conversations",
+    "attributeName": "conversation_attribute_9",
     "questions": ["wasHelpful"]
   },
   {
-    "insightsObject": "customers",
-    "attributeName": "customer_attribute_10",
+    "insightsObject": "conversations",
+    "attributeName": "conversation_attribute_10",
     "questions": ["wouldRecommend"]
   }
 ]

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -136,7 +136,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
     }
 
     // Message to send back to the user. This will be a localized string later on.
-    const say = 'Thank you again for reaching out. Please contact us again if you need more help.';
+    const say = 'Thank you for reaching out. Please contact us again if you need more help.';
 
     // This is the tasks that are sent back to the bot. For now, it just sends a thanks message before finishing bot's execution.
     const actions = [

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -136,7 +136,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
     }
 
     // Message to send back to the user. This will be a localized string later on.
-    const say = 'Thanks!';
+    const say = 'Thank you again for reaching out. Please contact us again if you need more help.';
 
     // This is the tasks that are sent back to the bot. For now, it just sends a thanks message before finishing bot's execution.
     const actions = [

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -111,7 +111,7 @@ const getTriggerMessage = (event: Body): string => {
     }
   }
 
-  return 'Hey! Before you leave, can you answer a few questions about this contact?';
+  return 'Before you leave, would you be willing to answer a few questions about the service you recieved today?';
 };
 
 export const handler: ServerlessFunctionSignature = TokenValidator(

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -71,7 +71,16 @@ const triggerPostSurveyFlow = async (
 ) => {
   const client = context.getTwilioClient();
 
+  /** const messageResult = */
   await client.chat
+    .services(context.CHAT_SERVICE_SID)
+    .channels(channelSid)
+    .messages.create({
+      body: message,
+      xTwilioWebhookEnabled: 'true',
+    });
+
+  return client.chat
     .services(context.CHAT_SERVICE_SID)
     .channels(channelSid)
     .webhooks.create({
@@ -82,16 +91,6 @@ const triggerPostSurveyFlow = async (
         url: context.POST_SURVEY_BOT_CHAT_URL,
       },
     });
-
-  const messageResult = await client.chat
-    .services(context.CHAT_SERVICE_SID)
-    .channels(channelSid)
-    .messages.create({
-      body: message,
-      xTwilioWebhookEnabled: 'true',
-    });
-
-  return messageResult;
 };
 
 const getTriggerMessage = (event: Body): string => {


### PR DESCRIPTION
## Description
This PR takes a different approach to the post survey:
- Ask the user if can take a survey.
- Add the chatbot to the channel.
  - If the user replies yes, the survey takes place.
  - If the user replies no, the survey is cancelled (address not saving blank data in HRM).
  - If the user does not replies, the task will timeout (adjust the timeout, rn is 30 seconds).