### PR TITLE
Fixed wrong usage of Twitter channel

### DIFF
--- a/functions/helpers/customChannels/customChannelToFlex.private.ts
+++ b/functions/helpers/customChannels/customChannelToFlex.private.ts
@@ -99,7 +99,7 @@ export const removeChatChannel = async (
     .remove();
 
 export enum AseloCustomChannels {
-  Twtter = 'twitter',
+  Twitter = 'twitter',
   Instagram = 'instagram',
 }
 

--- a/functions/webhooks/twitter/TwitterToFlex.ts
+++ b/functions/webhooks/twitter/TwitterToFlex.ts
@@ -98,7 +98,7 @@ export const handler = async (
 
       const senderExternalId = directMessageEvents[0].message_create.sender_id;
       const subscribedExternalId = forUserId;
-      const channelType = channelToFlex.AseloCustomChannels.Instagram;
+      const channelType = channelToFlex.AseloCustomChannels.Twitter;
       const twilioNumber = `${channelType}:${subscribedExternalId}`;
       const chatFriendlyName = `${channelType}:${senderExternalId}`;
       const uniqueUserName = `${channelType}:${senderExternalId}`;


### PR DESCRIPTION
## Description
Fixes a bug introduced in https://github.com/techmatters/serverless/pull/206: `instagram` `channelType` was being set for Twitter based tasks.
Also fixes a bad spelling.