### PR TITLE
Delete postSurveyMessages.private.json

### DIFF
--- a/assets/translations/en-US/postSurveyMessages.private.json
+++ b/assets/translations/en-US/postSurveyMessages.private.json
@@ -1,3 +1,0 @@
-{
-  "triggerMessage": "Hey! Before you leave, can you answer a few questions about this contact?"
-}


### PR DESCRIPTION
We changed the default messaging in the initiate post survey function, so we don't need this template file anymore for Canada.