### PR TITLE
Add static key auth to savePendingContacts

### DIFF
--- a/.github/actions/custom-actions/safernet_production_custom/action.yml
+++ b/.github/actions/custom-actions/safernet_production_custom/action.yml
@@ -13,7 +13,7 @@ runs:
       with:
         ssm_parameter: "PROD_SAFERNET_TOKEN"
         env_variable_name: "SAFERNET_TOKEN"
-    - name: Set SAFERNET_ENDPOINT
+    - name: Set SAVE_PENDING_CONTACTS_STATIC_KEY
       uses: "marvinpinto/action-inject-ssm-secrets@latest"
       with:
         ssm_parameter: "PROD_TWILIO_BR_SAVE_PENDING_CONTACTS_STATIC_KEY"

--- a/.github/actions/custom-actions/safernet_production_custom/action.yml
+++ b/.github/actions/custom-actions/safernet_production_custom/action.yml
@@ -13,6 +13,11 @@ runs:
       with:
         ssm_parameter: "PROD_SAFERNET_TOKEN"
         env_variable_name: "SAFERNET_TOKEN"
+    - name: Set SAFERNET_ENDPOINT
+      uses: "marvinpinto/action-inject-ssm-secrets@latest"
+      with:
+        ssm_parameter: "PROD_TWILIO_BR_SAVE_PENDING_CONTACTS_STATIC_KEY"
+        env_variable_name: "SAVE_PENDING_CONTACTS_STATIC_KEY"
     # Append environment variables
     - name: Add SAFERNET_ENDPOINT
       run: echo "SAFERNET_ENDPOINT=${{ env.SAFERNET_ENDPOINT }}" >> .env
@@ -22,5 +27,8 @@ runs:
       shell: bash
     - name: Add SAVE_CONTACT_FN
       run: echo "SAVE_CONTACT_FN=saveContactToSaferNet" >> .env
+      shell: bash
+    - name: Add SAVE_PENDING_CONTACTS_STATIC_KEY
+      run: echo "SAVE_PENDING_CONTACTS_STATIC_KEY=${{ env.SAVE_PENDING_CONTACTS_STATIC_KEY }}" >> .env
       shell: bash
     

--- a/.github/actions/custom-actions/safernet_staging_custom/action.yml
+++ b/.github/actions/custom-actions/safernet_staging_custom/action.yml
@@ -13,7 +13,7 @@ runs:
       with:
         ssm_parameter: "STG_SAFERNET_TOKEN"
         env_variable_name: "SAFERNET_TOKEN"
-    - name: Set SAFERNET_ENDPOINT
+    - name: Set SAVE_PENDING_CONTACTS_STATIC_KEY
       uses: "marvinpinto/action-inject-ssm-secrets@latest"
       with:
         ssm_parameter: "STG_TWILIO_BR_SAVE_PENDING_CONTACTS_STATIC_KEY"

--- a/.github/actions/custom-actions/safernet_staging_custom/action.yml
+++ b/.github/actions/custom-actions/safernet_staging_custom/action.yml
@@ -13,6 +13,11 @@ runs:
       with:
         ssm_parameter: "STG_SAFERNET_TOKEN"
         env_variable_name: "SAFERNET_TOKEN"
+    - name: Set SAFERNET_ENDPOINT
+      uses: "marvinpinto/action-inject-ssm-secrets@latest"
+      with:
+        ssm_parameter: "STG_TWILIO_BR_SAVE_PENDING_CONTACTS_STATIC_KEY"
+        env_variable_name: "SAVE_PENDING_CONTACTS_STATIC_KEY"
     # Append environment variables
     - name: Add SAFERNET_ENDPOINT
       run: echo "SAFERNET_ENDPOINT=${{ env.SAFERNET_ENDPOINT }}" >> .env
@@ -22,5 +27,8 @@ runs:
       shell: bash
     - name: Add SAVE_CONTACT_FN
       run: echo "SAVE_CONTACT_FN=saveContactToSaferNet" >> .env
+      shell: bash
+    - name: Add SAVE_PENDING_CONTACTS_STATIC_KEY
+      run: echo "SAVE_PENDING_CONTACTS_STATIC_KEY=${{ env.SAVE_PENDING_CONTACTS_STATIC_KEY }}" >> .env
       shell: bash
     

--- a/functions/saveContactToSaferNet.ts
+++ b/functions/saveContactToSaferNet.ts
@@ -4,62 +4,102 @@ import {
   ServerlessCallback,
   ServerlessFunctionSignature,
 } from '@twilio-labs/serverless-runtime-types/types';
-import { responseWithCors, bindResolve, error500, success } from '@tech-matters/serverless-helpers';
+import {
+  responseWithCors,
+  bindResolve,
+  error500,
+  error403,
+  success,
+} from '@tech-matters/serverless-helpers';
 import axios from 'axios';
 import crypto from 'crypto';
 
-const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+const validateToken = require('twilio-flex-token-validator').validator;
 
 export type Body = {
   payload: string;
+  Token?: string;
+  ApiKey?: string;
 };
 
 type EnvVars = {
+  ACCOUNT_SID: string;
+  AUTH_TOKEN: string;
+  SAVE_PENDING_CONTACTS_STATIC_KEY: string;
   SAFERNET_ENDPOINT: string;
   SAFERNET_TOKEN: string;
 };
 
-export const handler: ServerlessFunctionSignature = TokenValidator(
-  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
-    const response = responseWithCors();
-    const resolve = bindResolve(callback)(response);
+const isValidRequest = async (context: Context<EnvVars>, event: Body) => {
+  const { ACCOUNT_SID, AUTH_TOKEN, SAVE_PENDING_CONTACTS_STATIC_KEY } = context;
+  const { Token, ApiKey } = event;
 
+  if (Token) {
     try {
-      const { SAFERNET_ENDPOINT, SAFERNET_TOKEN } = context;
-
-      if (!SAFERNET_ENDPOINT) throw new Error('SAFERNET_ENDPOINT env var not provided.');
-      if (!SAFERNET_TOKEN) throw new Error('SAFERNET_TOKEN env var not provided.');
-
-      const { payload } = event;
-
-      const signedPayload = crypto
-        .createHmac('sha256', SAFERNET_TOKEN)
-        .update(encodeURIComponent(payload))
-        .digest('hex');
-
-      const saferNetResponse = await axios({
-        url: SAFERNET_ENDPOINT,
-        method: 'POST',
-        data: JSON.parse(payload),
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Signature': `sha256=${signedPayload}`,
-        },
-      });
-
-      if (saferNetResponse.data.success) {
-        resolve(success(saferNetResponse.data.post_survey_link));
-      } else {
-        const errorMessage = saferNetResponse.data.error_message;
-
-        // eslint-disable-next-line no-console
-        console.error(errorMessage);
-        resolve(error500(new Error(errorMessage)));
-      }
+      await validateToken(Token, ACCOUNT_SID, AUTH_TOKEN);
+      return true;
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-      resolve(error500(err));
+      return false;
     }
-  },
-);
+  } else if (ApiKey) {
+    return ApiKey === SAVE_PENDING_CONTACTS_STATIC_KEY;
+  }
+
+  return false;
+};
+
+export const handler: ServerlessFunctionSignature<EnvVars, Body> = async (
+  context: Context<EnvVars>,
+  event: Body,
+  callback: ServerlessCallback,
+) => {
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  const isValid = await isValidRequest(context, event);
+
+  if (!isValid) {
+    resolve(error403('No AccessToken or ApiKey was found'));
+    return;
+  }
+
+  try {
+    const { SAFERNET_ENDPOINT, SAFERNET_TOKEN } = context;
+
+    if (!SAFERNET_ENDPOINT) throw new Error('SAFERNET_ENDPOINT env var not provided.');
+    if (!SAFERNET_TOKEN) throw new Error('SAFERNET_TOKEN env var not provided.');
+
+    const { payload } = event;
+
+    const signedPayload = crypto
+      .createHmac('sha256', SAFERNET_TOKEN)
+      .update(encodeURIComponent(payload))
+      .digest('hex');
+
+    const saferNetResponse = await axios({
+      url: SAFERNET_ENDPOINT,
+      method: 'POST',
+      data: JSON.parse(payload),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Signature': `sha256=${signedPayload}`,
+      },
+    });
+
+    if (saferNetResponse.data.success) {
+      resolve(success(saferNetResponse.data.post_survey_link));
+    } else {
+      const errorMessage = saferNetResponse.data.error_message;
+
+      // eslint-disable-next-line no-console
+      console.warn(errorMessage);
+      resolve(error500(new Error(errorMessage)));
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(err);
+    resolve(error500(err));
+  }
+};
+
+export type SaveContact = typeof handler;

--- a/functions/saveContactToSaferNet.ts
+++ b/functions/saveContactToSaferNet.ts
@@ -56,6 +56,13 @@ export const handler: ServerlessFunctionSignature<EnvVars, Body> = async (
   const response = responseWithCors();
   const resolve = bindResolve(callback)(response);
 
+  const { SAFERNET_ENDPOINT, SAFERNET_TOKEN, SAVE_PENDING_CONTACTS_STATIC_KEY } = context;
+
+  if (!SAFERNET_ENDPOINT) throw new Error('SAFERNET_ENDPOINT env var not provided.');
+  if (!SAFERNET_TOKEN) throw new Error('SAFERNET_TOKEN env var not provided.');
+  if (!SAVE_PENDING_CONTACTS_STATIC_KEY)
+    throw new Error('SAVE_PENDING_CONTACTS_STATIC_KEY env var not provided.');
+
   const isValid = await isValidRequest(context, event);
 
   if (!isValid) {
@@ -64,11 +71,6 @@ export const handler: ServerlessFunctionSignature<EnvVars, Body> = async (
   }
 
   try {
-    const { SAFERNET_ENDPOINT, SAFERNET_TOKEN } = context;
-
-    if (!SAFERNET_ENDPOINT) throw new Error('SAFERNET_ENDPOINT env var not provided.');
-    if (!SAFERNET_TOKEN) throw new Error('SAFERNET_TOKEN env var not provided.');
-
     const { payload } = event;
 
     const signedPayload = crypto

--- a/functions/savePendingContacts.ts
+++ b/functions/savePendingContacts.ts
@@ -75,17 +75,19 @@ export const handler: ServerlessFunctionSignature<EnvVars, Body> = async (
   const response = responseWithCors();
   const resolve = bindResolve(callback)(response);
 
+  const { SYNC_SERVICE_SID, SAVE_CONTACT_FN, SAVE_PENDING_CONTACTS_STATIC_KEY } = context;
+
+  if (!SAVE_CONTACT_FN) throw new Error('SAVE_CONTACT_FN env var not provided.');
+  if (!SAVE_PENDING_CONTACTS_STATIC_KEY)
+    throw new Error('SAVE_PENDING_CONTACTS_STATIC_KEY env var not provided.');
+
   const isValid = await isValidRequest(context, event);
 
   if (!isValid) {
     return resolve(error403('No ApiKey was found'));
   }
 
-  const { SYNC_SERVICE_SID, SAVE_CONTACT_FN } = context;
-
   try {
-    if (!SAVE_CONTACT_FN) throw new Error('SAVE_CONTACT_FN env var not provided.');
-
     const saveContactFn = getSaveContactFn(SAVE_CONTACT_FN, context, event);
     if (!saveContactFn) {
       return resolve(error500(new Error('Could not find a saveContact function'))); // Should it be HTTP 404?


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
This changes how some functions related to save pending contacts handle authorization.

- `/savePendingContacts`: Previously used `twilio-flex-token-validator.functionValidator` wrapper. Now it looks for a static key.
- `/saveContactToSaferNet`: Previously used `twilio-flex-token-validator.functionValidator` wrapper. Now it uses a combination of `twilio-flex-token-validator.validator` (notice it's not `functionValidator`) or checks for a static key.

With these changes we're able to achieve two things:

1. An external function (AWS lambda) can call `/savePendingContacts` in a secure way using a static key
2. `/saveContactToSaferNet` can be called in a secure way from two different sources: from Aselo app using a Twilio's generated AccessToken; or from an external function using a static key.

### Related Issues
Fixes https://bugs.benetech.org/browse/CHI-1065
lambda PR: https://github.com/techmatters/infrastructure-config
