### PR TITLE
Fix saveContactToSaferNet to accept objects or string

### DIFF
--- a/functions/saveContactToSaferNet.ts
+++ b/functions/saveContactToSaferNet.ts
@@ -72,16 +72,17 @@ export const handler: ServerlessFunctionSignature<EnvVars, Body> = async (
 
   try {
     const { payload } = event;
+    const payloadAsString = typeof payload === 'string' ? payload : JSON.stringify(payload);
 
     const signedPayload = crypto
       .createHmac('sha256', SAFERNET_TOKEN)
-      .update(encodeURIComponent(payload))
+      .update(encodeURIComponent(payloadAsString))
       .digest('hex');
 
     const saferNetResponse = await axios({
       url: SAFERNET_ENDPOINT,
       method: 'POST',
-      data: JSON.parse(payload),
+      data: JSON.parse(payloadAsString),
       headers: {
         'Content-Type': 'application/json',
         'X-Signature': `sha256=${signedPayload}`,


### PR DESCRIPTION
## Description
Small bug correction:
When `/saveContactToSaferNet` is called via lambda, a payload object was being passed instead of a payload string.
This PR fixes `/saveContactToSaferNet` so that it works with either payload type.
