### PR TITLE
Support Instagram message deletion webhooks

### DIFF
--- a/.github/actions/custom-actions/aselo_development_custom/action.yml
+++ b/.github/actions/custom-actions/aselo_development_custom/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Set helpline Facebook Page Access Token
       uses: "marvinpinto/action-inject-ssm-secrets@latest"
       with:
-        ssm_parameter: "FACEBOOK_PAGE_ACCESS_TOKEN_105220114492262_TL-Staging"
+        ssm_parameter: "FACEBOOK_PAGE_ACCESS_TOKEN_105220114492262_TL-Development"
         env_variable_name: "FACEBOOK_PAGE_ACCESS_TOKEN"
     - name: Set helpline Instagram Flex Flow SID
       uses: "marvinpinto/action-inject-ssm-secrets@latest"

--- a/functions/helpers/customChannels/customChannelToFlex.private.ts
+++ b/functions/helpers/customChannels/customChannelToFlex.private.ts
@@ -3,7 +3,7 @@ import { Context } from '@twilio-labs/serverless-runtime-types/types';
 /**
  * Looks in Sync Service for the userChannelMap named after uniqueUserName
  */
-const retrieveChannelFromUserChannelMap = async (
+export const retrieveChannelFromUserChannelMap = async (
   context: Context,
   {
     syncServiceSid,
@@ -62,11 +62,13 @@ export const sendChatMessage = async (
     channelSid,
     from,
     messageText,
+    messageAttributes,
   }: {
     chatServiceSid: string;
     channelSid: string;
     from: string;
     messageText: string;
+    messageAttributes?: string;
   },
 ) => {
   const message = await context
@@ -77,6 +79,7 @@ export const sendChatMessage = async (
       body: messageText,
       from,
       xTwilioWebhookEnabled: 'true',
+      ...(messageAttributes && { attributes: messageAttributes }),
     });
 
   return message;
@@ -199,6 +202,7 @@ const createFlexChannel = async (
 type SendMessageToFlexParams = CreateFlexChannelParams & {
   syncServiceSid: string; // The Sync Service sid where user channel maps are stored
   messageText: string; // The body of the message to send
+  messageAttributes?: string; // [optional] The message attributes
   senderExternalId: string; // The id in the external chat system of the user sending the message
   subscribedExternalId: string; // The id in the external chat system of the user that is subscribed to the webhook
 };
@@ -224,6 +228,7 @@ export const sendMessageToFlex = async (
     onChannelUpdatedWebhookUrl,
     syncServiceSid,
     messageText,
+    messageAttributes = undefined,
     senderExternalId,
     subscribedExternalId,
   }: SendMessageToFlexParams,
@@ -281,6 +286,7 @@ export const sendMessageToFlex = async (
     channelSid,
     from: uniqueUserName,
     messageText,
+    messageAttributes,
   });
 
   return { status: 'sent', response };
@@ -288,5 +294,6 @@ export const sendMessageToFlex = async (
 
 export type ChannelToFlex = {
   sendMessageToFlex: typeof sendMessageToFlex;
+  retrieveChannelFromUserChannelMap: typeof retrieveChannelFromUserChannelMap;
   AseloCustomChannels: typeof AseloCustomChannels;
 };

--- a/functions/webhooks/instagram/InstagramToFlex.ts
+++ b/functions/webhooks/instagram/InstagramToFlex.ts
@@ -56,12 +56,15 @@ export type Body = InstagramMessageEvent & {
   bodyAsString?: string; // entire payload as string (preserves the ordering to decode and compare with xHubSignature)
 };
 
-const shouldFilterMessage = (message: InstagramMessageObject['message']) => {
-  // Filter story mention
-  if (message.attachments && message.attachments[0].type === 'story_mention') return true;
+const isMessageDeleted = (message: InstagramMessageObject['message']) => message.is_deleted;
 
-  return false;
-};
+const isStoryMention = (message: InstagramMessageObject['message']) =>
+  message.attachments && message.attachments[0].type === 'story_mention';
+
+const getStoryMentionText = (message: InstagramMessageObject['message']) =>
+  message.attachments
+    ? `Story mention: ${message.attachments[0].payload.url}`
+    : 'Looks like this event does not includes a valid url in the payload';
 
 const unsendMessage = async (
   context: Context,
@@ -127,11 +130,7 @@ export const handler = async (
 
     const { message, sender } = event.entry[0].messaging[0];
 
-    if (shouldFilterMessage(message)) {
-      resolve(success('Filtered event.'));
-      return;
-    }
-
+    let messageText = '';
     const senderExternalId = sender.id;
     const messageExternalId = message.mid;
     const subscribedExternalId = event.entry[0].id;
@@ -140,14 +139,13 @@ export const handler = async (
     const chatFriendlyName = `${channelType}:${senderExternalId}`;
     const uniqueUserName = `${channelType}:${senderExternalId}`;
     const senderScreenName = uniqueUserName; // TODO: see if we can use ig handle somehow
-    const messageText = message.text || '';
     const messageAttributes = JSON.stringify({ messageExternalId });
     const onMessageSentWebhookUrl = `https://${context.DOMAIN_NAME}/webhooks/instagram/FlexToInstagram?recipientId=${senderExternalId}`;
     const chatServiceSid = context.CHAT_SERVICE_SID;
     const syncServiceSid = context.SYNC_SERVICE_SID;
 
     // Handle message deletion for active conversations
-    if (message.is_deleted) {
+    if (isMessageDeleted(message)) {
       const channelSid = await channelToFlex.retrieveChannelFromUserChannelMap(context, {
         syncServiceSid,
         uniqueUserName,
@@ -172,6 +170,28 @@ export const handler = async (
       );
       return;
     }
+
+    // Handle story tags for active conversations
+    if (isStoryMention(message)) {
+      const channelSid = await channelToFlex.retrieveChannelFromUserChannelMap(context, {
+        syncServiceSid,
+        uniqueUserName,
+      });
+
+      if (channelSid) {
+        messageText = getStoryMentionText(message);
+      } else {
+        resolve(
+          success(
+            `Story mention with external id ${messageExternalId} is not part of an active conversation.`,
+          ),
+        );
+        return;
+      }
+    }
+
+    // If messageText is empty at this point, handle as a "regular Instagram message"
+    messageText = messageText || message.text || '';
 
     const result = await channelToFlex.sendMessageToFlex(context, {
       flexFlowSid: context.INSTAGRAM_FLEX_FLOW_SID,

--- a/functions/webhooks/instagram/InstagramToFlex.ts
+++ b/functions/webhooks/instagram/InstagramToFlex.ts
@@ -80,11 +80,11 @@ const unsendMessage = async (
     .channels(channelSid)
     .messages.list();
 
-  const messageToUnsed = messages.find(
+  const messageToUnsend = messages.find(
     m => JSON.parse(m.attributes).messageExternalId === messageExternalId,
   );
 
-  const unsent = await messageToUnsed?.update({ body: 'The user has unsent this message' });
+  const unsent = await messageToUnsend?.update({ body: 'The user has unsent this message' });
 
   return unsent;
 };

--- a/tests/webhooks/instagram/InstagramToFlex.test.ts
+++ b/tests/webhooks/instagram/InstagramToFlex.test.ts
@@ -80,6 +80,12 @@ const validEventBody = ({
   senderId = 'sender_id',
   recipientId = 'recipient_id',
   isDeleted = false,
+  attachments = undefined,
+}: {
+  senderId?: string;
+  recipientId?: string;
+  isDeleted?: boolean;
+  attachments?: any[];
 } = {}): Body => ({
   object: 'instagram',
   bodyAsString: defaultBodyAsString,
@@ -101,6 +107,7 @@ const validEventBody = ({
             mid: 'test_message_mid',
             text: 'test message text',
             is_deleted: isDeleted,
+            attachments,
           },
         },
       ],
@@ -265,7 +272,7 @@ describe('InstagramToFlex', () => {
       expectedToCreateChannel: MOCK_OTHER_CHANNEL_SID,
     },
     {
-      conditionDescription: 'deleting a message from an innactive conversation',
+      conditionDescription: 'deleting a message from an inactive conversation',
       event: validEventBody({ senderId: 'no_active_chat', isDeleted: true }),
       expectedStatus: 200,
       expectedMessage:
@@ -282,6 +289,30 @@ describe('InstagramToFlex', () => {
       expectedToCreateChannel: undefined,
       expectedToDeleteMessage: true,
     },
+    {
+      conditionDescription: 'story tagging from an inactive conversation',
+      event: validEventBody({
+        senderId: 'no_active_chat',
+        attachments: [{ type: 'story_mention', payload: { url: 'some fake url' } }],
+      }),
+      expectedStatus: 200,
+      expectedMessage:
+        'Story mention with external id test_message_mid is not part of an active conversation.',
+      expectedToBeSentOnChannel: undefined,
+      expectedToCreateChannel: undefined,
+    },
+    {
+      conditionDescription: 'story tagging from an inactive conversation',
+      event: validEventBody({
+        senderId: 'sender_id',
+        attachments: [{ type: 'story_mention', payload: { url: 'some fake url' } }],
+      }),
+      expectedStatus: 200,
+      expectedMessage: `Message sent in channel ${MOCK_SENDER_CHANNEL_SID}.`,
+      expectedToBeSentOnChannel: MOCK_SENDER_CHANNEL_SID,
+      expectedToCreateChannel: undefined,
+      expectedMessageText: 'Story mention: some fake url',
+    },
   ]).test(
     "Should return expectedStatus '$expectedMessage' when $conditionDescription",
     async ({
@@ -293,6 +324,7 @@ describe('InstagramToFlex', () => {
       expectedToBeSentOnChannel,
       expectedToCreateChannel,
       expectedToDeleteMessage = false,
+      expectedMessageText = undefined,
     }) => {
       let response: MockedResponse | undefined;
 
@@ -317,9 +349,10 @@ describe('InstagramToFlex', () => {
         if (expectedToBeSentOnChannel) {
           expect(channels[expectedToBeSentOnChannel].messages.create).toBeCalledWith(
             expect.objectContaining({
-              body: 'test message text',
+              body: expectedMessageText || 'test message text',
               from: expectedToBeSentOnChannel,
               xTwilioWebhookEnabled: 'true',
+              attributes: JSON.stringify({ messageExternalId: 'test_message_mid' }),
             }),
           );
         } else {


### PR DESCRIPTION
Primary reviewer: @murilovmachado  

## Description
This PR adds support for Instagram message deletion according to the specs in the ticket (link below). The changes are:
- Fixed wrong Parameter Store credential being pulled from in Aselo Development deployment (Facebook page name has changed and credentials regenerated so the old one is not valid anymore).
- Exporting helper function to retrieve the active chat channel for a given user (if it exists). If no channel is returned, then the user does not have an active conversation.
- Added support to include message attributes when sending a message to Flex in a custom channel.
- All Instagram messages now include it's message id (coming from Instagram) in the message attributes, under the propery `messageExternalId`.
- When a message is unset (deleted) on Instagram:
  - If the user has an active chat, looks for the message in the chat channel that matches with the `messageExternalId`, and edit it to indicate it has been deleted.
  - If the user does not have active channel, we skip the event.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1174)
- [x] New tests added

### Verification steps
Not sure anyone else can test this, as only people with developer role in the IG app can trigger the webhooks. In case you can, this modifications are already deployed to Aselo dev environment, so to test:
- Send an Instagram message to @aselodevelopment ig account.
- Receive the resulting task in Flex.
- [Optional] Exchange some messages.
- Delete one or more messages sent by the user and confirm they are properly deleted.
- Capture the chat channel sid to use in later step.
- End the chat.
- Try deleting messages now that there is no active conversation (nothing should happen).
- Check that the deleting messages on Instagram does not delete any message on Twilio system when chat is not active anymore.
