### PR TITLE
Support Instagram story mentions

### DIFF
--- a/functions/webhooks/instagram/InstagramToFlex.ts
+++ b/functions/webhooks/instagram/InstagramToFlex.ts
@@ -173,9 +173,6 @@ export const handler = async (
 
     // Handle story tags for active conversations
     if (isStoryMention(message)) {
-      console.log(fromStoryMention(message));
-      console.log(message.attachments && message.attachments[0].payload);
-
       const channelSid = await channelToFlex.retrieveChannelFromUserChannelMap(context, {
         syncServiceSid,
         uniqueUserName,

--- a/functions/webhooks/instagram/InstagramToFlex.ts
+++ b/functions/webhooks/instagram/InstagramToFlex.ts
@@ -61,10 +61,10 @@ const isMessageDeleted = (message: InstagramMessageObject['message']) => message
 const isStoryMention = (message: InstagramMessageObject['message']) =>
   message.attachments && message.attachments[0].type === 'story_mention';
 
-const fromStoryMention = (message: InstagramMessageObject['message']) =>
+const getStoryMentionText = (message: InstagramMessageObject['message']) =>
   message.attachments
     ? `Story mention: ${message.attachments[0].payload.url}`
-    : 'Looks like this event does not incluydes a valid url in the payload';
+    : 'Looks like this event does not includes a valid url in the payload';
 
 const unsendMessage = async (
   context: Context,
@@ -179,7 +179,7 @@ export const handler = async (
       });
 
       if (channelSid) {
-        messageText = fromStoryMention(message);
+        messageText = getStoryMentionText(message);
       } else {
         resolve(
           success(

--- a/tests/webhooks/instagram/InstagramToFlex.test.ts
+++ b/tests/webhooks/instagram/InstagramToFlex.test.ts
@@ -272,7 +272,7 @@ describe('InstagramToFlex', () => {
       expectedToCreateChannel: MOCK_OTHER_CHANNEL_SID,
     },
     {
-      conditionDescription: 'deleting a message from an innactive conversation',
+      conditionDescription: 'deleting a message from an inactive conversation',
       event: validEventBody({ senderId: 'no_active_chat', isDeleted: true }),
       expectedStatus: 200,
       expectedMessage:
@@ -290,7 +290,7 @@ describe('InstagramToFlex', () => {
       expectedToDeleteMessage: true,
     },
     {
-      conditionDescription: 'story tagging from an innactive conversation',
+      conditionDescription: 'story tagging from an inactive conversation',
       event: validEventBody({
         senderId: 'no_active_chat',
         attachments: [{ type: 'story_mention', payload: { url: 'some fake url' } }],
@@ -302,7 +302,7 @@ describe('InstagramToFlex', () => {
       expectedToCreateChannel: undefined,
     },
     {
-      conditionDescription: 'story tagging from an innactive conversation',
+      conditionDescription: 'story tagging from an inactive conversation',
       event: validEventBody({
         senderId: 'sender_id',
         attachments: [{ type: 'story_mention', payload: { url: 'some fake url' } }],


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description
This PR handles story tagging in a slightly different way. Before we were always ignoring this events, now we:
- Ignore the event if the user does not have an active covnersation.
- Redirect the media cdn (temporary url) of the story if the user has an active conversation.
![Screenshot from 2022-06-10 17-45-38](https://user-images.githubusercontent.com/15805319/173155645-bd1e3a94-eeb4-4f2e-b71b-d35ddc690f2a.png)


### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1173)
- [x] New tests added

### Verification steps
Not sure anyone else can test this, as only people with developer role in the IG app can trigger the webhooks. In case you can, this modifications are already deployed to Aselo dev environment, so to test:
- Send an Instagram message to @aselodevelopment ig account.
- Receive the resulting task in Flex.
- [Optional] Exchange some messages.
- Tag in a story the  @aselodevelopment and see the message is properly displayed as above image shows.
- Capture the chat channel sid to use in later step.
- End the chat.
- Tag in a story the  @aselodevelopment now that there is no active conversation (nothing should happen).
- Check that no message was sent on Twilio system when chat is not active anymore.
