### PR TITLE
Add dependabot config to reduce PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"
+        
+  - package-ecosystem: "npm"
+    directory: "/tech-matters-serverless-helpers-lib/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"
+        
+  - package-ecosystem: "npm"
+    directory: "/.github/actions/main-action/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"
+
+  - package-ecosystem: "npm"
+    directory: "/.github/actions/deploy-beta/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Creates a `dependabot.yml` file similar to the one in https://github.com/techmatters/flex-plugins/pull/803 to limit dependabot updates to only security updates that affect `dependencies` (not `devDependencies`) and do not trigger PRs for normal version updates.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
