### PR TITLE
[Bug Fix] Custom channel user-to-channel maps linked to stale channels

### DIFF
--- a/functions/helpers/chatChannelJanitor.private.ts
+++ b/functions/helpers/chatChannelJanitor.private.ts
@@ -1,7 +1,7 @@
 /**
  * In order to make post surveys work, we need to disable the Channel Janitor (see https://www.twilio.com/docs/flex/developer/messaging/manage-flows#channel-janitor).
  * However, once the post survey is finished we want to mimic this feature to clear the channel and the proxy session, to enable future conversations from the same customer
- * Ths file exposes functionalities to achieve this. postSurveyJanitor will:
+ * Ths file exposes functionalities to achieve this. chatChannelJanitor will:
  * - Label the chat channel as INACTIVE.
  * - Delete the associated proxy session if there is one.
  */
@@ -11,7 +11,6 @@ import type { Context } from '@twilio-labs/serverless-runtime-types/types';
 
 export interface Event {
   channelSid: string;
-  channelType: 'chat';
 }
 
 type EnvVars = {
@@ -70,19 +69,13 @@ const deactivateChannel = async (
   return updated;
 };
 
-export const postSurveyJanitor = async (
+export const chatChannelJanitor = async (
   context: Context<EnvVars>,
   event: Event
 ) => {
-  console.log('-------- postSurveyJanitor execution --------');
+  await deactivateChannel(context, context.CHAT_SERVICE_SID, event.channelSid);
 
-  if (event.channelType === 'chat') {
-    await deactivateChannel(context, context.CHAT_SERVICE_SID, event.channelSid);
-
-    return { message: `Deactivation successful for channel ${event.channelSid}` };
-  }
-
-  return { message: 'Ignored event' };
+  return { message: `Deactivation successful for channel ${event.channelSid}` };
 };
 
-export type PostSurveyJanitor = typeof postSurveyJanitor;
+export type ChatChannelJanitor = typeof chatChannelJanitor;

--- a/functions/helpers/customChannels/customChannelToFlex.private.ts
+++ b/functions/helpers/customChannels/customChannelToFlex.private.ts
@@ -106,6 +106,9 @@ export enum AseloCustomChannels {
   Instagram = 'instagram',
 }
 
+export const isAseloCustomChannel = (s: unknown): s is AseloCustomChannels =>
+  Object.values(AseloCustomChannels).includes(s as any);
+
 type CreateFlexChannelParams = {
   flexFlowSid: string;
   chatServiceSid: string;
@@ -296,4 +299,5 @@ export type ChannelToFlex = {
   sendMessageToFlex: typeof sendMessageToFlex;
   retrieveChannelFromUserChannelMap: typeof retrieveChannelFromUserChannelMap;
   AseloCustomChannels: typeof AseloCustomChannels;
+  isAseloCustomChannel: typeof isAseloCustomChannel;
 };

--- a/functions/webhooks/taskrouterCallback.protected.ts
+++ b/functions/webhooks/taskrouterCallback.protected.ts
@@ -57,7 +57,7 @@ const isCleanupPostSurvey = (eventType: EventType, taskAttributes: { isSurveyTas
   (eventType === TASK_CANCELED_EVENT || eventType === TASK_COMPLETED_EVENT) && taskAttributes.isSurveyTask;
 
 const isCleanupCustomChannel = (eventType: EventType, taskAttributes: { channelType?: string }) => {
-  if (!(eventType === TASK_DELETED_EVENT || eventType === TASK_SYSTEM_DELETED_EVENT)) return false;
+  if (!(eventType === TASK_DELETED_EVENT || eventType === TASK_SYSTEM_DELETED_EVENT || eventType === TASK_CANCELED_EVENT)) return false;
 
   const handlerPath = Runtime.getFunctions()['helpers/customChannels/customChannelToFlex'].path;
   const channelToFlex = require(handlerPath) as ChannelToFlex;

--- a/functions/webhooks/taskrouterCallback.protected.ts
+++ b/functions/webhooks/taskrouterCallback.protected.ts
@@ -15,14 +15,8 @@ import { responseWithCors, bindResolve, success, error500 } from '@tech-matters/
 
 // eslint-disable-next-line prettier/prettier
 import type { AddCustomerExternalId } from '../helpers/addCustomerExternalId.private';
-// eslint-disable-next-line prettier/prettier
-import type { PostSurveyJanitor } from '../helpers/postSurveyJanitor.private';
-
-export type Body = {
-  EventType: string;
-  TaskSid?: string;
-  TaskAttributes?: string;
-};
+import type { ChatChannelJanitor } from '../helpers/chatChannelJanitor.private';
+import type { ChannelToFlex } from '../helpers/customChannels/customChannelToFlex.private';
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;
@@ -33,11 +27,42 @@ type EnvVars = {
 const TASK_CREATED_EVENT = 'task.created';
 const TASK_CANCELED_EVENT = 'task.canceled';
 const TASK_COMPLETED_EVENT = 'task.completed';
+const TASK_DELETED_EVENT = 'task.deleted';
+const TASK_SYSTEM_DELETED_EVENT = 'task.system-deleted';
+
+// Note: there are more of this, we just list the ones we care about. https://www.twilio.com/docs/taskrouter/api/event/reference
+const eventTypes = [
+  TASK_CREATED_EVENT,
+  TASK_CANCELED_EVENT,
+  TASK_COMPLETED_EVENT,
+  TASK_DELETED_EVENT,
+  TASK_SYSTEM_DELETED_EVENT,
+] as const;
+
+type EventType = typeof eventTypes[number];
+
+export type Body = {
+  EventType: EventType;
+  TaskSid?: string;
+  TaskAttributes?: string;
+};
 
 const wait = (ms: number): Promise<void> => {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+};
+
+const isCleanupPostSurvey = (eventType: EventType, taskAttributes: { isSurveyTask?: boolean }) =>
+  (eventType === TASK_CANCELED_EVENT || eventType === TASK_COMPLETED_EVENT) && taskAttributes.isSurveyTask;
+
+const isCleanupCustomChannel = (eventType: EventType, taskAttributes: { channelType?: string }) => {
+  if (!(eventType === TASK_DELETED_EVENT || eventType === TASK_SYSTEM_DELETED_EVENT)) return false;
+
+  const handlerPath = Runtime.getFunctions()['helpers/customChannels/customChannelToFlex'].path;
+  const channelToFlex = require(handlerPath) as ChannelToFlex;
+
+  return channelToFlex.isAseloCustomChannel(taskAttributes.channelType);
 };
 
 export const handler = async (
@@ -49,14 +74,14 @@ export const handler = async (
   const resolve = bindResolve(callback)(response);
 
   try {
-    const { EventType } = event;
+    const { EventType: eventType } = event;
 
-    if (EventType === TASK_CREATED_EVENT) {
+    if (eventType === TASK_CREATED_EVENT) {
       const handlerPath = Runtime.getFunctions()['helpers/addCustomerExternalId'].path;
       const addCustomerExternalId = require(handlerPath).addCustomerExternalId as AddCustomerExternalId;
       await addCustomerExternalId(context, event);
 
-      const message = `Event ${EventType} handled by /helpers/addCustomerExternalId`;
+      const message = `Event ${eventType} handled by /helpers/addCustomerExternalId`;
       console.log(message);
       resolve(
         success(
@@ -68,33 +93,48 @@ export const handler = async (
       return;
     }
 
-    if (EventType === TASK_CANCELED_EVENT || EventType === TASK_COMPLETED_EVENT) {
-      const taskAttributes = JSON.parse(event.TaskAttributes!);
+    const taskAttributes = JSON.parse(event.TaskAttributes!);
 
-      if (taskAttributes.isSurveyTask) {
-        await wait(3000); // wait 3 seconds just in case some bot message is pending
+    if (isCleanupPostSurvey(eventType, taskAttributes)) {
+      await wait(3000); // wait 3 seconds just in case some bot message is pending
 
-        const handlerPath = Runtime.getFunctions()['helpers/postSurveyJanitor'].path;
-        const postSurveyJanitor = require(handlerPath).postSurveyJanitor as PostSurveyJanitor;
-        await postSurveyJanitor(context, { channelSid: taskAttributes.channelSid, channelType: 'chat' });
+      const handlerPath = Runtime.getFunctions()['helpers/chatChannelJanitor'].path;
+      const chatChannelJanitor = require(handlerPath).chatChannelJanitor as ChatChannelJanitor;
+      await chatChannelJanitor(context, { channelSid: taskAttributes.channelSid });
   
-        const message = `Event ${EventType} handled by /helpers/postSurveyJanitor`;
-        console.log(message);
-        resolve(
-          success(
-            JSON.stringify({
-              message,
-            }),
-          ),
-        );
-        return;
-      }
+      const message = `Event matched isCleanupPostSurvey for task sid ${event.TaskSid}`;
+      console.log(message);
+      resolve(
+        success(
+          JSON.stringify({
+            message,
+          }),
+        ),
+      );
+      return;
     }
 
-    resolve(success(JSON.stringify({ message: 'Ignored event', EventType })));
+    if (isCleanupCustomChannel(eventType, taskAttributes)) {
+      const handlerPath = Runtime.getFunctions()['helpers/chatChannelJanitor'].path;
+      const chatChannelJanitor = require(handlerPath).chatChannelJanitor as ChatChannelJanitor;
+
+      await chatChannelJanitor(context, { channelSid: taskAttributes.channelSid });
+
+      const message = `Event matched isCleanupCustomChannel for task sid ${event.TaskSid}`;
+      console.log(message);
+      resolve(
+        success(
+          JSON.stringify({
+            message,
+          }),
+        ),
+      );
+      return;
+    }
+
+    resolve(success(JSON.stringify({ message: 'Ignored event', eventType })));
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(err);
-    resolve(error500(err));
+    if (err instanceof Error) resolve(error500(err));
+    else resolve(error500(new Error(String(err))));
   }
 };


### PR DESCRIPTION
Primary Reviewer: @murilovmachado 

## Description
This PR:
- Renames `postSurveyJanitor` to a more general and descriptive one: `chatChannelJanitor`.
- Exposes a small helper to indicate if a channel is `AseloCustomChannel`.
- Adds a new condition on taskrouter callback to perform cleanup on custom channels (prevents stale state).

Notes:
- After this PR is merged, check that the taskrouter webhook url points to `-production` (currently pointing to `-dev`).
- In order for this changes to take effect in existing accounts, we need to enable two more events on taskrouter webhook: `task.deleted` and `task.system-deleted`.
- Above item means that we need to address this in the terraform scripts too (deferring PR on that until this one is approved & merged).

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1321)
- [ ] New tests added


### Verification steps
#### To test cancelled event:
- Decrease the timeout in "send to flex" widget for Twitter or Instagram, under Messaging Studio Flow (both works on the same functions) to something that allows for faster iterations (30 seconds should be enough).
- Check that your user does not have a channel-to-user map under sync -> documents.
- Send a new message via the selected platform.
- DO NOT accepted the generated task in Flex, we want it to expire (so it's cancelled).
- Go in and check that now you do have a channel-to-user map under sync -> documents. Copy the channel sid in it.
- After the task is cancelled, check that the channel-to-user map under sync -> documents is deleted. Also the channel used (above copeid sid) should be marked as INACTIVE.
- :exclamation: Remember to rollback any changes you've made in the Studio Flow.
#### To test deleted event:
- Decrease the "send to flex" widget for Twitter or Instagram (both works on the same functions) to something that allows for faster iterations.
- Check that your user does not have a channel-to-user map under sync -> documents.
- Send a new message via the selected platform.
- Accept the generated task in Flex.
- Go in and check that now you do have a channel-to-user map under sync -> documents. Copy the channel sid in it.
- Go to taskrouter -> tasks and deleted the task you got generated from the Twilio console.
- After the task is deleted, check that the channel-to-user map under sync -> documents is deleted. Also the channel used (above copeid sid) should be marked as INACTIVE.
