### PR TITLE
Reduce error logs

### DIFF
--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -91,8 +91,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       return resolve(send(status)({ message, status }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       return resolve(error500(err));
     }
   },

--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -215,8 +215,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(assignmentResult.newTask));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/autopilotRedirect.protected.ts
+++ b/functions/autopilotRedirect.protected.ts
@@ -72,8 +72,6 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
     callback(null, returnObj);
   } catch (err) {
     // If something goes wrong, just handoff to counselor so contact is not lost
-    // eslint-disable-next-line no-console
-    console.error(err);
     callback(null, { actions: [{ redirect: 'task://counselor_handoff' }] });
   }
 };

--- a/functions/createContactlessTask.ts
+++ b/functions/createContactlessTask.ts
@@ -68,8 +68,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(newTask));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/deleteFile.ts
+++ b/functions/deleteFile.ts
@@ -59,8 +59,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ deletedFile: fileName }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/getFileDownloadUrl.ts
+++ b/functions/getFileDownloadUrl.ts
@@ -51,8 +51,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ downloadUrl }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/getFileUploadUrl.ts
+++ b/functions/getFileUploadUrl.ts
@@ -52,8 +52,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ uploadUrl, fileNameAtAws }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/getMessages.ts
+++ b/functions/getMessages.ts
@@ -35,8 +35,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(translation));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/getTranslation.ts
+++ b/functions/getTranslation.ts
@@ -35,8 +35,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(translation));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/getWorkerAttributes.ts
+++ b/functions/getWorkerAttributes.ts
@@ -54,8 +54,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(whiteListedAttributes));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/healthCheck.ts
+++ b/functions/healthCheck.ts
@@ -22,8 +22,6 @@ export const handler: ServerlessFunctionSignature = async (
   try {
     resolve(success(msg));
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(err);
     resolve(error500(err));
   }
 };

--- a/functions/issueSyncToken.ts
+++ b/functions/issueSyncToken.ts
@@ -60,8 +60,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ token: accessToken.toJwt() }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/listWorkerQueues.ts
+++ b/functions/listWorkerQueues.ts
@@ -39,8 +39,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       return resolve(success({ workerQueues }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       return resolve(error500(err));
     }
   },

--- a/functions/operatingHours.ts
+++ b/functions/operatingHours.ts
@@ -96,8 +96,6 @@ export const handler = async (
 
     resolve(success('closed'));
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(err);
     resolve(error500(err));
   }
 };

--- a/functions/populateCounselors.ts
+++ b/functions/populateCounselors.ts
@@ -73,8 +73,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ workerSummaries }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -148,8 +148,6 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
 
     callback(null, JSON.stringify(returnObj));
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(err);
     callback(null, { actions: [] });
   }
 };

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -131,8 +131,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       return resolve(success(JSON.stringify({ message: 'Post survey init OK!' })));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       return resolve(error500(err));
     }
   },

--- a/functions/reportToIWF.ts
+++ b/functions/reportToIWF.ts
@@ -109,8 +109,6 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = TokenValidat
 
       return resolve(send(report.status)(report.data));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       return resolve(error500(err as any));
     }
   },

--- a/functions/sendSystemMessage.ts
+++ b/functions/sendSystemMessage.ts
@@ -70,8 +70,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success(messageResult));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/transferChatResolve.ts
+++ b/functions/transferChatResolve.ts
@@ -162,8 +162,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ closed: closedTask.sid, kept: keptTask.sid }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -260,8 +260,6 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       resolve(success({ taskSid: newTask.sid }));
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
       resolve(error500(err));
     }
   },

--- a/tests/helpers/addCustomerExternalId.test.ts
+++ b/tests/helpers/addCustomerExternalId.test.ts
@@ -2,7 +2,22 @@ import { addCustomerExternalId, Body } from '../../functions/helpers/addCustomer
 
 import helpers from '../helpers';
 
-let tasks: any[] = [];
+let tasks: any[] = [
+  {
+    sid: 'non-existing',
+    fetch: () => {
+      throw new Error("can't fetch this one!");
+    },
+  },
+  {
+    sid: 'non-updateable',
+    attributes: JSON.stringify({}),
+    fetch: async () => tasks.find(t => t.sid === 'non-updateable'),
+    update: () => {
+      throw new Error("can't update this one!");
+    },
+  },
+];
 
 const createTask = (sid: string, options: any) => {
   return {
@@ -19,10 +34,7 @@ const createTask = (sid: string, options: any) => {
 
 const workspaces: { [x: string]: any } = {
   WSxxx: {
-    tasks: (sid: string) => {
-      if (sid === 'non-existing') throw new Error('Not existing task');
-      return tasks.find(t => t.sid === sid);
-    },
+    tasks: (sid: string) => tasks.find(t => t.sid === sid),
   },
 };
 
@@ -41,29 +53,46 @@ const baseContext = {
 };
 
 const liveAttributes = { some: 'some', customers: { other: 1 } };
-const offlineAttributes = { some: 'some', isContactlessTask: true };
+
+const logSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
 beforeAll(() => {
   helpers.setup({});
-  tasks = [
-    ...tasks,
-    createTask('live-contact', { attributes: JSON.stringify(liveAttributes) }),
-    createTask('offline-contact', {
-      attributes: JSON.stringify(offlineAttributes),
-    }),
-  ];
+  tasks = [...tasks, createTask('live-contact', { attributes: JSON.stringify(liveAttributes) })];
 });
 afterAll(() => {
   helpers.teardown();
 });
+afterEach(() => {
+  logSpy.mockClear();
+});
 
-test('Should throw (Not existing task)', async () => {
+test("Should log and return error (can't fetch task)", async () => {
   const event: Body = {
     EventType: 'task.created',
     TaskSid: 'non-existing',
   };
 
-  expect(() => addCustomerExternalId(baseContext, event)).rejects.toThrowError('Not existing task');
+  const expectedError =
+    'Error at addCustomerExternalId: task with sid non-existing does not exists in workspace WSxxx when trying to fetch it.';
+
+  const result = await addCustomerExternalId(baseContext, event);
+  expect(result.message).toBe(expectedError);
+  expect(logSpy).toHaveBeenCalledWith(expectedError, new Error("can't fetch this one!"));
+});
+
+test("Should log and return error (can't update task)", async () => {
+  const event: Body = {
+    EventType: 'task.created',
+    TaskSid: 'non-updateable',
+  };
+
+  const expectedError =
+    'Error at addCustomerExternalId: task with sid non-updateable does not exists in workspace WSxxx when trying to update it.';
+
+  const result = await addCustomerExternalId(baseContext, event);
+  expect(result.message).toBe(expectedError);
+  expect(logSpy).toHaveBeenCalledWith(expectedError, new Error("can't update this one!"));
 });
 
 test('Should return OK (modify live contact)', async () => {
@@ -80,23 +109,10 @@ test('Should return OK (modify live contact)', async () => {
   });
 });
 
-test('Should return status 200 (ignores offline contact)', async () => {
-  const event: Body = {
-    EventType: 'task.created',
-    TaskSid: 'offline-contact',
-  };
-
-  const result = await addCustomerExternalId(baseContext, event);
-  expect(result.message).toBe('Is contactless task');
-  expect(JSON.parse(tasks.find(t => t.sid === 'offline-contact').attributes)).toEqual(
-    offlineAttributes,
-  );
-});
-
 test('Should return status 200 (ignores other events)', async () => {
   const event: Body = {
     EventType: 'other.event',
-    TaskSid: 'something',
+    TaskSid: 'live-contact',
   };
 
   const result = await addCustomerExternalId(baseContext, event);


### PR DESCRIPTION
Primary reviewer: @nickhurlburt 

## Description
This PR attempts to reduce the amount of times we get paged:
- Removes all `console.error`s in `catch` blocks that already raise a Twilio error webhook (as the function will return status code 500).
- Adds error handling on `functions/helpers/addCustomerExternalId.private.ts`, instead than throwing we'll `console.error`, so the Twilio error webhook is called once per occurrence. If this still occurs that can indicate an internal error.
- Moves around check to avoid calling above function for offline contacts, that is where we found conflicts because of the race condition between "removing task that can't be assigned" in `assignOfflineContact` and "adding external id" in the taskrouter callback. Can rollback if we prefer to keep that check inside of it tho.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added

### Verification steps
- I can help with this after deploying to development :)