### PR TITLE
[PoC]:Added logic to pass down helpline-identifier for custom actions (AS_DEV)

### DIFF
--- a/.github/actions/custom-actions/action.yml
+++ b/.github/actions/custom-actions/action.yml
@@ -1,5 +1,10 @@
 name: 'Execute per-helpline custom action'
 description: Compound 'routing' action to load custom deployment actions for the helpline being deployed
+inputs:
+  helpline-identifier:
+    description: 'The identifier in the format "<short helpline>-<short env>"" used for this helpline (e.g. "AS_DEV")'
+    required: true
+    type: string
 runs:
   using: "composite"
   steps:
@@ -13,7 +18,7 @@ runs:
       if: github.workflow == format('Aarambh Production release')
       uses: ./.github/actions/custom-actions/aarambh_production_custom
     - name: Aselo Development release custom action
-      if: github.workflow == format('Aselo Development release')
+      if: inputs.helpline-identifier == format('AS_DEV')
       uses: ./.github/actions/custom-actions/aselo_development_custom
     - name: Aselo Beta release custom action
       if: github.workflow == format('Aselo Beta release')

--- a/.github/actions/main-action/action.yml
+++ b/.github/actions/main-action/action.yml
@@ -58,6 +58,10 @@ inputs:
     required: false
     default: 'true'
     type: string
+  helpline-identifier:
+    description: 'The identifier in the format "<short helpline>-<short env>"" used for this helpline (e.g. "AS_DEV")'
+    required: true
+    type: string
 runs:
   using: "composite"
   steps:
@@ -100,6 +104,8 @@ runs:
     # Run custom action to perform per-helpline based actions
     - name: Execute custom action (if any)
       uses: ./.github/actions/custom-actions
+      with:
+        helpline-identifier: ${{ inputs.helpline-identifier }}
     # Install dependencies for the twilio functions
     - name: Install dependencies for the twilio functions
       run: npm ci

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -125,3 +125,4 @@ jobs:
           aselo-app-secret-key: $ASELO_APP_SECRET_KEY
           aws-region: $AWS_REGION
           s3-bucket: $S3_BUCKET
+          helpline-identifier: "AS_DEV"


### PR DESCRIPTION
Primary reviewer: @acedeywin 

## Description
This PoC shows how to change our custom actions to depend in an input instead than the "workflow name" as we were doing.
- Adds `helpline-identifier` as a required parameter for `.github/actions/custom-actions/action.yml`, to decide if a custom step should be triggered.
- Adds `helpline-identifier` as a required parameter for `.github/actions/main-action/action.yml`, and passes it down to `custom-actions` step.
- Adds "AS_DEV" as the the `helpline-identifier` for the Aselo Development deployment workflow

As you can see in [this action execution](https://github.com/techmatters/serverless/actions/runs/3228170666/jobs/5283910469), the custom action is executed, and the expected steps are taking place (see [aselo development custom](https://github.com/techmatters/serverless/blob/master/.github/actions/custom-actions/aselo_development_custom/action.yml) for reference).
![Screenshot from 2022-10-11 12-41-51](https://user-images.githubusercontent.com/15805319/195137643-441a2c7e-2269-4ea0-90ed-65a0e541f18b.png)

Next steps:
- If this `helpline-identifier` become required, that means that we have to change **every** workflow, whether it uses custom action or not. I think for sanity that makes sense, since we wanted the workflows to look all the exact same but using different helpline identifiers. This means that we can continue to use scripts to generate the workflows, and the only changes for custom actions will be within those files and not in the workflows. Can be convinced other way if you think this is not right.
- While this is a PoC, above item means we'll want to merge it if we decide that this is the easiest replacement for the "github workflow name" approach (which I do).

Asking review from @stephenhand that's already aware of this and suggested we take this path.

### Verification steps
- Run 
  ```curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer <yout GH token>" "https://api.github.com/repos/techmatters/serverless/actions/workflows/aselo_development.yml/dispatches" -d '{"ref":"gian_poc-custom-actions-helpline-name"}```
- Confirm that I'm not lying in the above statements :P