### PR TITLE
Added control flow to discriminate assigned state to end task in webchat

### DIFF
--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -86,7 +86,18 @@ export const handler = TokenValidator(
         default:
       }
 
-      resolve(success({ isTaskStageAssigned, message: 'End Chat Ok' }));
+      // Change the channel status to 'inactive'
+      channelAttributes.status = 'INACTIVE';
+      const channelUpdate = {
+        attributes: JSON.stringify(channelAttributes),
+      };
+
+      await client.chat
+        .services(context.CHAT_SERVICE_SID)
+        .channels(channelSid)
+        .update(channelUpdate);
+
+      resolve(success({ message: 'End Chat Ok' }));
       return;
     } catch (err: any) {
       resolve(error500(err));


### PR DESCRIPTION
## Description
- This PR along with this [PR]( https://github.com/techmatters/webchat/pull/134) in webchat has minor refactor to check task at assigned stage for triggering end chat more reliably


### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added


### Related Issues
Fixes #[CHI-1402](https://bugs.benetech.org/browse/CHI-1402)

### Verification steps
- Ensure this webchat [PR]( https://github.com/techmatters/webchat/pull/134) is running as well
