### PR TITLE
CHI-1458: Fix QA release version bumps

### DIFF
--- a/.github/workflows/serverless-pre-release-qa.yml
+++ b/.github/workflows/serverless-pre-release-qa.yml
@@ -77,7 +77,7 @@ jobs:
           tag-prefix: ${{ inputs.tag-prefix }}
           tag-suffix: 'qa'
           title: ${{ inputs.title }}
-          repository: ${{ github.event.repository.name }}
+          repository: ${{ github.repository }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
         id: create_pre_release
 


### PR DESCRIPTION
@GPaoloni 

## Description

Change serverless workflow to pass in `github.repository` when generating a release - will allow QA build revision bumps to work correctly

### Checklist
- [X] Corresponding issue has been opened
- N / A

### Related Issues
Fixes CHI-1458
### Verification steps

1. Release a version which already has a QA release
2. Check the released version is 1 QA revision higher than the previous highest revision
