### PR TITLE
Use chatChannelJanitor to cleanup after end chat in webchat

### DIFF
--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -9,10 +9,12 @@ import {
   functionValidator as TokenValidator,
 } from '@tech-matters/serverless-helpers';
 import type { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
+import { ChatChannelJanitor } from './helpers/chatChannelJanitor.private';
 
 type EnvVars = {
   CHAT_SERVICE_SID: string;
   TWILIO_WORKSPACE_SID: string;
+  FLEX_PROXY_SERVICE_SID: string;
 };
 
 export type Body = {
@@ -47,16 +49,18 @@ export const handler = TokenValidator(
         .tasks(channelAttributes.taskSid)
         .fetch();
 
-      // Send a Message
-      await context
-        .getTwilioClient()
-        .chat.services(context.CHAT_SERVICE_SID)
-        .channels(channelSid)
-        .messages.create({
-          body: 'User left the conversation.',
-          from: 'Bot',
-          xTwilioWebhookEnabled: 'true',
-        });
+      if (task.assignmentStatus === 'assigned') {
+        // Send a Message
+        await context
+          .getTwilioClient()
+          .chat.services(context.CHAT_SERVICE_SID)
+          .channels(channelSid)
+          .messages.create({
+            body: 'User left the conversation.',
+            from: 'Bot',
+            xTwilioWebhookEnabled: 'true',
+          });
+      }
 
       // Update the task assignmentStatus
       const updateAssignmentStatus = (assignmentStatus: TaskInstance['assignmentStatus']) =>
@@ -80,6 +84,12 @@ export const handler = TokenValidator(
         }
         default:
       }
+
+      /* TODO: Once logic for triggering post survey on task wrap is moved to taskRouterCallback, the following clean up can be removed */
+      // Deactivate channel and proxy
+      const handlerPath = Runtime.getFunctions()['helpers/chatChannelJanitor'].path;
+      const chatChannelJanitor = require(handlerPath).chatChannelJanitor as ChatChannelJanitor;
+      await chatChannelJanitor(context, { channelSid });
 
       resolve(success(JSON.stringify({ message: 'End Chat OK!' })));
       return;

--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -1,3 +1,5 @@
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
 import '@twilio-labs/serverless-runtime-types';
 import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
 import {

--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -52,7 +52,7 @@ export const handler = TokenValidator(
         .fetch();
 
       if (task.assignmentStatus === 'assigned') {
-        // Send a Message
+        // Send a Message  TODO:implement localization
         await context
           .getTwilioClient()
           .chat.services(context.CHAT_SERVICE_SID)


### PR DESCRIPTION
Primary Reviewer: @murilovmachado 

## Description
This PR has a minor addition to end chat function where it cleans up channel and proxy when a user ends the chat. Also, bot sent message is triggered only on assigned state

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes # 1402

### Verification steps
- In webchat, while checking in flex, run through the chat and 'end chat' while the task is in 'pending', 'reserved', and 'assigned'

