### PR TITLE
Localize EndChatMessage for use in endChat function

### DIFF
--- a/assets/translations/en-GB/messages.private.json
+++ b/assets/translations/en-GB/messages.private.json
@@ -1,3 +1,4 @@
 {
-  "GoodbyeMsg": "The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help."
+  "GoodbyeMsg": "The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.",
+  "EndChatMsg": "User left the conversation."
 }

--- a/assets/translations/en-US/messages.private.json
+++ b/assets/translations/en-US/messages.private.json
@@ -1,3 +1,4 @@
 {
-  "GoodbyeMsg": "The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help."
+  "GoodbyeMsg": "The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.",
+  "EndChatMsg": "You ended the chat. Thank you for reaching out. Please contact us again if you need more help."
 }

--- a/assets/translations/pt-BR/messages.private.json
+++ b/assets/translations/pt-BR/messages.private.json
@@ -1,0 +1,3 @@
+{
+  "EndChatMsg": "O usuário saiu da conversa."
+}

--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -30,7 +30,7 @@ type Messages = {
 };
 
 const getEndChatMessage = (event: Body): string => {
-  // Try to retrieve the triggerMessage for the approapriate language (if any)
+  // Retrieve the EndChatMsg for appropriate language
   const { language } = event;
 
   if (language) {
@@ -41,7 +41,7 @@ const getEndChatMessage = (event: Body): string => {
       const { EndChatMsg } = translation;
       if (EndChatMsg) return EndChatMsg;
     } catch {
-      console.error(`Couldn't retrieve EndChatMsg translation for ${language}`);
+      console.error(`Couldn't retrieve EndChatMsg message translation for ${language}`);
     }
   }
   return 'User left the conversation';


### PR DESCRIPTION
Primary Reviewer: @GPaoloni or @stephenhand 

## Description
- This PR localizes the `EndChatMsg` string - 'User left conversation' with language attribute in webchat's config
- Adds language as a request parameter for EndChat function
- Separation of `getEndChatMessage` logic and error handling
- Adds some assets for some of the languages

### Checklist
- [x] Corresponding issue has been opened
- [x] Strings are localized
- [ ] New tests added

### Related Issues
Fixes #1402

### Verification steps
- Ensuring this branch is deployed, in webchat (local or deployed dev), get to the part where 'End Chat' can be triggered. Check the Bot message
- To test localization, add or change `EndChatMsg` in `assets/translations/{language}/messages`
- Alternatively, in webchat, the language can be hardcoded to a different appropriate one.
