### PR TITLE
Localizing postSurvey "good bye" message

### DIFF
--- a/assets/translations/en-US/postSurveyMessages.private.json
+++ b/assets/translations/en-US/postSurveyMessages.private.json
@@ -1,3 +1,4 @@
 {
-  "triggerMessage": "Before you leave, would you be willing to answer a few questions about the service you received today? Please answer Yes or No."
+  "triggerMessage": "Before you leave, would you be willing to answer a few questions about the service you received today? Please answer Yes or No.",
+  "postSurvetCompleteMessage": "Thank you for reaching out. Please contact us again if you need more help."
 }

--- a/assets/translations/es/postSurveyMessages.private.json
+++ b/assets/translations/es/postSurveyMessages.private.json
@@ -1,3 +1,4 @@
 {
-  "triggerMessage": "Antes de partir, ¿estaría dispuesto a responder algunas preguntas sobre el servicio que recibió hoy? Por favor, responda Sí o No."
+  "triggerMessage": "Antes de partir, ¿estaría dispuesto a responder algunas preguntas sobre el servicio que recibió hoy? Por favor, responda Sí o No.",
+  "postSurvetCompleteMessage": "Gracias por contactarnos. Por favor, contáctenos nuevamente si necesita más ayuda."
 }

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -148,9 +148,9 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
           ) as OneToManyConfigSpec[];
 
           const surveyTaskAttributes = JSON.parse(surveyTask.attributes);
-
+Object.entries(([k, v]) => console.log(k, JSON.stringify(v)))
           // Set the taskLanguage carried over from the original task, if any
-          taskLanguage = surveyTaskAttributes.taskLanguage;
+          taskLanguage = surveyTaskAttributes.language;
 
           // parallel execution to save survey collected data in insights and hrm
           await Promise.all([

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -56,7 +56,6 @@ const saveSurveyInInsights = async (
     surveyTaskAttributes,
     memory,
   );
-  console.log('finalAttributes: ', JSON.stringify(finalAttributes));
 
   await surveyTask.update({ attributes: JSON.stringify(finalAttributes) });
 };
@@ -91,17 +90,19 @@ const saveSurveyInHRM = async (
   });
 };
 
-const getPostSurvetCompleteMessage = (taskLanguage: string | undefined): string => {
-  if (taskLanguage) {
-    try {
-      const translation = JSON.parse(
-        Runtime.getAssets()[`/translations/${taskLanguage}/postSurveyMessages.json`].open(),
-      );
+const getPostSurveyCompleteMessage = (taskLanguage: string | undefined): string => {
+  try {
+    const language = taskLanguage || 'en-US';
 
-      if (translation.postSurvetCompleteMessage) return translation.postSurvetCompleteMessage;
-    } catch {
-      console.error(`Couldn't retrieve postSurvetCompleteMessage translation for ${taskLanguage}`);
-    }
+    const translation = JSON.parse(
+      Runtime.getAssets()[`/translations/${language}/postSurveyMessages.json`].open(),
+    );
+
+    if (translation.postSurvetCompleteMessage) return translation.postSurvetCompleteMessage;
+  } catch {
+    console.error(
+      `Couldn't retrieve postSurvetCompleteMessage translation for ${taskLanguage}, neither default (en-US).`,
+    );
   }
 
   return 'Thank you for reaching out. Please contact us again if you need more help.';
@@ -179,7 +180,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
       }
     }
 
-    const say = getPostSurvetCompleteMessage(taskLanguage);
+    const say = getPostSurveyCompleteMessage(taskLanguage);
 
     // This is the tasks that are sent back to the bot. For now, it just sends a thanks message before finishing bot's execution.
     const actions = [

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -113,7 +113,6 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
   callback: ServerlessCallback,
 ) => {
   console.log('-------- postSurveyComplete execution --------');
-  Object.entries(event).forEach(([k, v]) => console.log(k, JSON.stringify(v)));
 
   try {
     const memory = JSON.parse(event.Memory);
@@ -148,9 +147,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
           ) as OneToManyConfigSpec[];
 
           const surveyTaskAttributes = JSON.parse(surveyTask.attributes);
-          Object.entries(surveyTaskAttributes).forEach(([k, v]) =>
-            console.log(k, JSON.stringify(v)),
-          );
+
           // Set the taskLanguage carried over from the original task, if any
           taskLanguage = surveyTaskAttributes.language;
 

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -148,7 +148,9 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
           ) as OneToManyConfigSpec[];
 
           const surveyTaskAttributes = JSON.parse(surveyTask.attributes);
-Object.entries(([k, v]) => console.log(k, JSON.stringify(v)))
+          Object.entries(surveyTaskAttributes).forEach(([k, v]) =>
+            console.log(k, JSON.stringify(v)),
+          );
           // Set the taskLanguage carried over from the original task, if any
           taskLanguage = surveyTaskAttributes.language;
 

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -105,7 +105,6 @@ const getTriggerMessage = (event: Body): string => {
 export const handler = TokenValidator(
   async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
     console.log('-------- postSurveyInit execution --------');
-    console.log('event', event);
 
     const response = responseWithCors();
     const resolve = bindResolve(callback)(response);

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -35,7 +35,7 @@ const createSurveyTask = async (
     channelSid,
     contactTaskId: taskSid,
     conversations: { conversation_id: taskSid },
-    taskLanguage, // if there's a taskLanguage, attach it to the post survey task
+    language: taskLanguage, // if there's a task language, attach it to the post survey task
   };
 
   const surveyTask = await client.taskrouter.workspaces(context.TWILIO_WORKSPACE_SID).tasks.create({
@@ -105,6 +105,7 @@ const getTriggerMessage = (event: Body): string => {
 export const handler = TokenValidator(
   async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
     console.log('-------- postSurveyInit execution --------');
+    console.log('event', event);
 
     const response = responseWithCors();
     const resolve = bindResolve(callback)(response);


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description
This PR adds the ability to localize the "post survey complete". The way this is done is, the original (contact) task contains a `language` attribute, it will be passed down to the post survey task when is created (`/postSurveyInit`). This `language` property is retrieved when the survey is completed (`/postSurveyComplete`) and used to retrieve the translation, if it exists.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1371)
- [ ] New tests added

### Verification steps
Note: this is deployed to development to make testing easier,
- Start a new chat contact and accept it from Flex.
- Edit the generated task from Twilio Console, adding the attribute `"language": "es"`.
- Complete the task from Flex.
- Take the post survey from the contact's view and confirm that the last message (when the post survey is done) is translated.