### PR TITLE
CHI-1578: Queue Transfer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,6 @@ module.exports = {
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/indent": "off",
     "no-console": "off",
-    "no-shadow": "off"
+    "no-shadow": "off",
   },
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "printWidth": 100,
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "all",
-  "tabWidth": 2
-}

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -45,7 +45,7 @@ const isChatTransfer = (
   taskAttributes.transferMeta.mode === 'COLD' &&
   taskAttributes.transferMeta.transferStatus === 'accepted';
 
-const isChatTransferAccepted = (
+const isChatTransferToWorkerAccepted = (
   eventType: EventType,
   taskChannelUniqueName: string,
   taskAttributes: ChatTransferTaskAttributes,
@@ -54,7 +54,7 @@ const isChatTransferAccepted = (
   isChatTransfer(taskChannelUniqueName, taskAttributes) &&
   taskAttributes.transferTargetType === 'worker';
 
-const isChatTransferRejected = (
+const isChatTransferToWorkerRejected = (
   eventType: EventType,
   taskChannelUniqueName: string,
   taskAttributes: ChatTransferTaskAttributes,
@@ -66,7 +66,7 @@ const isChatTransferRejected = (
 const isChatTransferToQueueComplete = (
   eventType: EventType,
   taskChannelUniqueName: string,
-  taskAttributes: { transferMeta?: TransferMeta; transferTargetType: 'worker' | 'queue' },
+  taskAttributes: ChatTransferTaskAttributes,
 ) =>
   eventType === TASK_QUEUE_ENTERED &&
   isChatTransfer(taskChannelUniqueName, taskAttributes) &&
@@ -114,7 +114,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
      * If a chat transfer gets accepted, it should:
      * 1) Complete the original task
      */
-    if (isChatTransferAccepted(eventType, taskChannelUniqueName, taskAttributes)) {
+    if (isChatTransferToWorkerAccepted(eventType, taskChannelUniqueName, taskAttributes)) {
       console.log('Handling chat transfer accepted...');
 
       const { originalTask: originalTaskSid } = taskAttributes.transferMeta;
@@ -162,7 +162,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
      *    - transferMeta.sidWithTaskControl: to original reservation
      * 2) Cancel rejected task
      */
-    if (isChatTransferRejected(eventType, taskChannelUniqueName, taskAttributes)) {
+    if (isChatTransferToWorkerRejected(eventType, taskChannelUniqueName, taskAttributes)) {
       console.log('Handling chat transfer rejected...');
 
       const { originalTask: originalTaskSid } = taskAttributes.transferMeta;

--- a/functions/webhooks/taskrouterCallback.protected.ts
+++ b/functions/webhooks/taskrouterCallback.protected.ts
@@ -46,7 +46,6 @@ export const handler = async (
   event: EventFields,
   callback: ServerlessCallback,
 ) => {
-  console.log(`Task Router Event ${event?.EventType} fired`);
   const response = responseWithCors();
   const resolve = bindResolve(callback)(response);
 

--- a/functions/webhooks/taskrouterCallback.protected.ts
+++ b/functions/webhooks/taskrouterCallback.protected.ts
@@ -96,6 +96,7 @@ export const handler = async (
   event: EventFields,
   callback: ServerlessCallback,
 ) => {
+  console.log(`Task Router Event ${event?.EventType} fired`, event);
   const response = responseWithCors();
   const resolve = bindResolve(callback)(response);
 

--- a/functions/webhooks/taskrouterCallback.protected.ts
+++ b/functions/webhooks/taskrouterCallback.protected.ts
@@ -96,7 +96,7 @@ export const handler = async (
   event: EventFields,
   callback: ServerlessCallback,
 ) => {
-  console.log(`Task Router Event ${event?.EventType} fired`, event);
+  console.log(`Task Router Event ${event?.EventType} fired`);
   const response = responseWithCors();
   const resolve = bindResolve(callback)(response);
 

--- a/package.json
+++ b/package.json
@@ -61,5 +61,13 @@
     "twit": "2.2.11",
     "type-fest": "2.19.0",
     "uuid": "8.3.2"
+  },
+  "prettier": {
+    "printWidth": 100,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "tabWidth": 2,
+    "endOfLine": "auto"
   }
 }

--- a/tech-matters-serverless-helpers-lib/.prettierrc
+++ b/tech-matters-serverless-helpers-lib/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "printWidth": 100,
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "all",
-  "tabWidth": 2
-}

--- a/tech-matters-serverless-helpers-lib/package.json
+++ b/tech-matters-serverless-helpers-lib/package.json
@@ -38,5 +38,14 @@
   "exports": {
     ".": "./lib/index.js",
     "./taskrouter": "./lib/taskrouter/index.js"
+  },
+  "prettier": {
+    "printWidth": 100,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "tabWidth": 2,
+    "endOfLine": "auto"
   }
+
 }


### PR DESCRIPTION
## Description

* Updates behaviour of chat transfers to treat transfers to queues differently to transfers to counsellors
* Move .prettierrc settings into package.jsons because a bug in webstorm means it doesn't pick them up from .prettierrc

The updated logic means that a 'queue' target transfer will complete the original task as soon as it hits a queue, rather than holding it open until accepted by a worker, which worker transfers do

It also limits the special logic for rejections to worker transfers. Queue transfers just go back on the queue if rejected now

### Checklist
- [X] Corresponding issue has been opened
- [x] New tests added


### Related Issues
Fixes CHI-1578

### Verification steps

See ticket
