### PR TITLE
Move task wrapup and post survey trigger logic from Flex to Serverless

### DIFF
--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -11,7 +11,6 @@ import {
   functionValidator as TokenValidator,
 } from '@tech-matters/serverless-helpers';
 import type { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
-import { ChatChannelJanitor } from './helpers/chatChannelJanitor.private';
 
 type EnvVars = {
   CHAT_SERVICE_SID: string;
@@ -116,12 +115,6 @@ export const handler = TokenValidator(
         }
         default:
       }
-
-      /* TODO: Once logic for triggering post survey on task wrap is moved to taskRouterCallback, the following clean up can be removed */
-      // Deactivate channel and proxy
-      const handlerPath = Runtime.getFunctions()['helpers/chatChannelJanitor'].path;
-      const chatChannelJanitor = require(handlerPath).chatChannelJanitor as ChatChannelJanitor;
-      await chatChannelJanitor(context, { channelSid });
 
       resolve(success(JSON.stringify({ message: 'End Chat OK!' })));
       return;

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -15,7 +15,7 @@ import type { PostSurveyInitHandler } from '../postSurveyInit';
 
 export const eventTypes: EventType[] = [TASK_WRAPUP];
 
-type EnvVars = {
+export type EnvVars = {
   CHAT_SERVICE_SID: string;
   TWILIO_WORKSPACE_SID: string;
   SURVEY_WORKFLOW_SID: string;

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -1,0 +1,120 @@
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
+import '@twilio-labs/serverless-runtime-types';
+import { Context } from '@twilio-labs/serverless-runtime-types/types';
+
+import {
+  TaskrouterListener,
+  EventFields,
+  EventType,
+  TASK_WRAPUP,
+} from '@tech-matters/serverless-helpers/taskrouter';
+import type { ChannelToFlex } from '../helpers/customChannels/customChannelToFlex.private';
+import type { TransferMeta } from './transfersListener.private';
+import type { PostSurveyInitHandler } from '../postSurveyInit';
+
+export const eventTypes: EventType[] = [TASK_WRAPUP];
+
+type EnvVars = {
+  CHAT_SERVICE_SID: string;
+  TWILIO_WORKSPACE_SID: string;
+  SURVEY_WORKFLOW_SID: string;
+  POST_SURVEY_BOT_CHAT_URL: string;
+};
+
+// ================== //
+// TODO: unify this code with Flex codebase
+
+const hasTransferStarted = (taskAttributes: {
+  transferMeta?: TransferMeta;
+}): taskAttributes is { transferMeta: TransferMeta } =>
+  Boolean(taskAttributes && taskAttributes.transferMeta);
+
+const hasTaskControl = (taskSid: string, taskAttributes: { transferMeta?: TransferMeta }) =>
+  !hasTransferStarted(taskAttributes) || taskAttributes.transferMeta.sidWithTaskControl === taskSid;
+
+const getTaskLanguage = (helplineLanguage: string) => (taskAttributes: { language?: string }) =>
+  taskAttributes.language || helplineLanguage;
+// ================== //
+
+const isTriggerPostSurvey = (
+  eventType: EventType,
+  taskSid: string,
+  taskChannelUniqueName: string,
+  taskAttributes: { channelType?: string; transferMeta?: TransferMeta },
+) => {
+  if (eventType !== TASK_WRAPUP) return false;
+
+  // Post survey is for chat tasks only. This will change when we introduce voice based post surveys
+  if (taskChannelUniqueName !== 'chat') return false;
+
+  if (!hasTaskControl(taskSid, taskAttributes)) return false;
+
+  // Post survey does not plays well with custom channels (autopilot)
+  const handlerPath = Runtime.getFunctions()['helpers/customChannels/customChannelToFlex'].path;
+  const channelToFlex = require(handlerPath) as ChannelToFlex;
+
+  if (channelToFlex.isAseloCustomChannel(taskAttributes.channelType)) return false;
+
+  return true;
+};
+
+/**
+ * Checks the event type to determine if the listener should handle the event or not.
+ * If it returns true, the taskrouter will invoke this listener.
+ */
+export const shouldHandle = (event: EventFields) => eventTypes.includes(event.EventType);
+
+export const handleEvent = async (context: Context<EnvVars>, event: EventFields) => {
+  try {
+    const {
+      EventType: eventType,
+      TaskChannelUniqueName: taskChannelUniqueName,
+      TaskSid: taskSid,
+      TaskAttributes: taskAttributesString,
+    } = event;
+
+    console.log(`===== Executing PostSurveyListener for event: ${eventType} =====`);
+
+    const taskAttributes = JSON.parse(taskAttributesString);
+
+    if (isTriggerPostSurvey(eventType, taskSid, taskChannelUniqueName, taskAttributes)) {
+      console.log('Handling post survey trigger...');
+      const client = context.getTwilioClient();
+
+      // This task is a candidate to trigger post survey. Check feature flags for the account.
+      const serviceConfig = await client.flexApi.configuration.get().fetch();
+      const { feature_flags: featureFlags, helplineLanguage } = serviceConfig.attributes;
+
+      if (featureFlags.enable_post_survey && featureFlags.post_survey_serverless_handled) {
+        const { channelSid } = taskAttributes;
+
+        const taskLanguage = getTaskLanguage(helplineLanguage)(taskAttributes);
+
+        const handlerPath = Runtime.getFunctions()['postSurveyInit.ts'].path;
+        const postSurveyInitHandler = require(handlerPath)
+          .postSurveyInitHandler as PostSurveyInitHandler;
+
+        await postSurveyInitHandler(context, { channelSid, taskSid, taskLanguage });
+
+        console.log('Finished handling post survey trigger.');
+      }
+    }
+    console.log('===== PostSurveyListener finished successfully =====');
+  } catch (err) {
+    console.log('===== PostSurveyListener has failed =====');
+    console.log(String(err));
+    throw err;
+  }
+};
+
+/**
+ * The taskrouter callback expects that all taskrouter listeners return
+ * a default object of type TaskrouterListener.
+ */
+const postSurveyListener: TaskrouterListener = {
+  shouldHandle,
+  handleEvent,
+};
+
+export default postSurveyListener;

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -86,6 +86,8 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       const serviceConfig = await client.flexApi.configuration.get().fetch();
       const { feature_flags: featureFlags, helplineLanguage } = serviceConfig.attributes;
 
+      /** ==================== */
+      // TODO: Once all accounts are ready to manage triggering post survey on task wrap within taskRouterCallback, the check on post_survey_serverless_handled can be removed
       if (featureFlags.enable_post_survey && featureFlags.post_survey_serverless_handled) {
         const { channelSid } = taskAttributes;
 

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -91,7 +91,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
         const taskLanguage = getTaskLanguage(helplineLanguage)(taskAttributes);
 
-        const handlerPath = Runtime.getFunctions()['postSurveyInit.ts'].path;
+        const handlerPath = Runtime.getFunctions().postSurveyInit.path;
         const postSurveyInitHandler = require(handlerPath)
           .postSurveyInitHandler as PostSurveyInitHandler;
 

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -26,9 +26,10 @@ type EnvVars = {
   TWILIO_WORKSPACE_SID: string;
 };
 
-type TransferMeta = {
+export type TransferMeta = {
   mode: 'COLD' | 'WARM';
   transferStatus: 'transferring' | 'accepted' | 'rejected';
+  sidWithTaskControl: string;
 };
 
 type ChatTransferTaskAttributes = {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": "^12.0"
+    "node": "^14.0"
   },
   "dependencies": {
     "@tech-matters/serverless-helpers": "3.0.5",

--- a/tests/taskrouterListeners/postSurveyListener.test.ts
+++ b/tests/taskrouterListeners/postSurveyListener.test.ts
@@ -1,0 +1,196 @@
+import {
+  EventFields,
+  EventType,
+  TASK_CREATED,
+  TASK_WRAPUP,
+  TASK_CANCELED,
+  TASK_DELETED,
+  TASK_SYSTEM_DELETED,
+  TASK_COMPLETED,
+  TASK_UPDATED,
+} from '@tech-matters/serverless-helpers/taskrouter';
+import { Context } from '@twilio-labs/serverless-runtime-types/types';
+import { mock } from 'jest-mock-extended';
+import each from 'jest-each';
+
+import * as postSurveyListener from '../../functions/taskrouterListeners/postSurveyListener.private';
+import * as postSurveyInit from '../../functions/postSurveyInit';
+import { AseloCustomChannels } from '../../functions/helpers/customChannels/customChannelToFlex.private';
+
+const functions = {
+  postSurveyInit: {
+    path: '../postSurveyInit',
+  },
+  'helpers/customChannels/customChannelToFlex': {
+    path: '../helpers/customChannels/customChannelToFlex.private.ts',
+  },
+};
+global.Runtime.getFunctions = () => functions;
+
+jest.mock('../../functions/postSurveyInit');
+
+// const mockFeatureFlags = {};
+// const mockFetchConfig = jest.fn(() => ({ attributes: { feature_flags: mockFeatureFlags } }));
+const mockFetchConfig = jest.fn();
+const context = {
+  ...mock<Context<postSurveyListener.EnvVars>>(),
+  getTwilioClient: (): any => ({
+    flexApi: {
+      configuration: {
+        get: () => ({
+          fetch: mockFetchConfig,
+        }),
+      },
+    },
+  }),
+  TWILIO_WORKSPACE_SID: 'WSxxx',
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Post survey init', () => {
+  // Candidate tasks that should trigger post survey if external conditions are met
+  const nonTrasferred = {
+    taskSid: 'non-trasferred',
+    taskChannelUniqueName: 'chat',
+    attributes: { transferMeta: undefined, channelType: 'web' },
+  };
+
+  const successfullyTrasferred = {
+    taskSid: 'successfully-trasferred',
+    taskChannelUniqueName: 'chat',
+    attributes: {
+      transferMeta: { sidWithTaskControl: 'successfully-trasferred', channelType: 'web' },
+    },
+  };
+
+  each(
+    [
+      TASK_CREATED,
+      TASK_CANCELED,
+      TASK_DELETED,
+      TASK_SYSTEM_DELETED,
+      TASK_COMPLETED,
+      TASK_UPDATED,
+    ].flatMap((eventType: string) => [
+      { task: nonTrasferred, eventType },
+      { task: successfullyTrasferred, eventType },
+    ]),
+  ).test(
+    'Task event type $eventType should not trigger post survey for candidate taskSid $task.taskSid',
+    async ({ eventType, task }) => {
+      const event = {
+        ...mock<EventFields>(),
+        EventType: eventType,
+        TaskAttributes: JSON.stringify(task.attributes),
+        TaskChannelUniqueName: task.taskChannelUniqueName,
+        TaskSid: task.taskSid,
+      };
+
+      const postSurveyInitHandlerSpy = jest.spyOn(postSurveyInit, 'postSurveyInitHandler');
+
+      await postSurveyListener.handleEvent(context, event);
+
+      expect(mockFetchConfig).not.toHaveBeenCalled();
+      expect(postSurveyInitHandlerSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  each([
+    {
+      task: {
+        ...nonTrasferred,
+        taskChannelUniqueName: 'voice',
+      },
+      rejectReason: 'is not chat task',
+    },
+    {
+      task: {
+        ...successfullyTrasferred,
+        taskChannelUniqueName: 'chat',
+        attributes: {
+          ...successfullyTrasferred.attributes,
+          transferMeta: { sidWithTaskControl: 'a-different-one' },
+        },
+      },
+      rejectReason: 'does not have task controll (incomplete/rejected transfer)',
+    },
+    ...Object.values(AseloCustomChannels).map((channelType) => ({
+      task: {
+        ...nonTrasferred,
+        taskChannelUniqueName: 'chat',
+        attributes: { ...nonTrasferred.attributes, channelType },
+      },
+      rejectReason: `is custom channel ${channelType}`,
+    })),
+    {
+      task: nonTrasferred,
+      isCandidate: true,
+      featureFlags: { enable_post_survey: true, post_survey_serverless_handled: false },
+      rejectReason: 'is candidate but post_survey_serverless_handled === false',
+    },
+    {
+      task: nonTrasferred,
+      isCandidate: true,
+      featureFlags: { enable_post_survey: false, post_survey_serverless_handled: true },
+      rejectReason: 'is candidate but enable_post_survey === false',
+    },
+  ]).test(
+    'Task should not trigger post survey because $rejectReason',
+    async ({ task, featureFlags, isCandidate }) => {
+      const event = {
+        ...mock<EventFields>(),
+        EventType: TASK_WRAPUP as EventType,
+        TaskAttributes: JSON.stringify(task.attributes),
+        TaskChannelUniqueName: task.taskChannelUniqueName,
+        TaskSid: task.taskSid,
+      };
+
+      mockFetchConfig.mockReturnValue({
+        attributes: { feature_flags: featureFlags || {} },
+      });
+
+      const postSurveyInitHandlerSpy = jest.spyOn(postSurveyInit, 'postSurveyInitHandler');
+
+      await postSurveyListener.handleEvent(context, event);
+
+      // If isCandidate, it will reach service config checks
+      if (isCandidate) {
+        expect(mockFetchConfig).toHaveBeenCalled();
+      } else {
+        expect(mockFetchConfig).not.toHaveBeenCalled();
+      }
+      expect(postSurveyInitHandlerSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  each([nonTrasferred, successfullyTrasferred].map((task) => ({ task }))).test(
+    'Task should trigger post survey for candidate taskSid $task.taskSid',
+    async ({ task }) => {
+      const event = {
+        ...mock<EventFields>(),
+        EventType: TASK_WRAPUP as EventType,
+        TaskAttributes: JSON.stringify(task.attributes),
+        TaskChannelUniqueName: task.taskChannelUniqueName,
+        TaskSid: task.taskSid,
+      };
+
+      mockFetchConfig.mockReturnValue({
+        attributes: {
+          feature_flags: { enable_post_survey: true, post_survey_serverless_handled: true },
+        },
+      });
+
+      const postSurveyInitHandlerSpy = jest
+        .spyOn(postSurveyInit, 'postSurveyInitHandler')
+        .mockImplementationOnce(async () => {});
+
+      await postSurveyListener.handleEvent(context, event);
+
+      expect(mockFetchConfig).toHaveBeenCalled();
+      expect(postSurveyInitHandlerSpy).toHaveBeenCalled();
+    },
+  );
+});

--- a/tests/webhooks/instagram/InstagramToFlex.test.ts
+++ b/tests/webhooks/instagram/InstagramToFlex.test.ts
@@ -199,7 +199,7 @@ describe('InstagramToFlex', () => {
       conditionDescription: 'the event contains no entry',
       event: { ...validEventBody(), entry: [] },
       expectedStatus: 500,
-      expectedMessage: 'Cannot read properties',
+      expectedMessage: 'Cannot read property',
     },
     {
       conditionDescription: 'the event has an entry with empty messaging',
@@ -219,7 +219,7 @@ describe('InstagramToFlex', () => {
         ],
       },
       expectedStatus: 500,
-      expectedMessage: 'Cannot read properties',
+      expectedMessage: 'Cannot read property',
     },
     {
       conditionDescription: 'the event has no message',
@@ -233,7 +233,7 @@ describe('InstagramToFlex', () => {
         ],
       },
       expectedStatus: 500,
-      expectedMessage: 'Cannot read properties',
+      expectedMessage: 'Cannot read property',
     },
     {
       conditionDescription:

--- a/tests/webhooks/instagram/InstagramToFlex.test.ts
+++ b/tests/webhooks/instagram/InstagramToFlex.test.ts
@@ -199,13 +199,13 @@ describe('InstagramToFlex', () => {
       conditionDescription: 'the event contains no entry',
       event: { ...validEventBody(), entry: [] },
       expectedStatus: 500,
-      expectedMessage: 'Cannot read property',
+      expectedMessage: 'Cannot read properties',
     },
     {
       conditionDescription: 'the event has an entry with empty messaging',
       event: { ...validEventBody(), entry: [{ ...validEventBody().entry[0], messaging: [] }] },
       expectedStatus: 500,
-      expectedMessage: 'Cannot read property',
+      expectedMessage: 'Cannot destructure property',
     },
     {
       conditionDescription: 'the event has no sender',
@@ -219,7 +219,7 @@ describe('InstagramToFlex', () => {
         ],
       },
       expectedStatus: 500,
-      expectedMessage: 'Cannot read property',
+      expectedMessage: 'Cannot read properties',
     },
     {
       conditionDescription: 'the event has no message',
@@ -233,7 +233,7 @@ describe('InstagramToFlex', () => {
         ],
       },
       expectedStatus: 500,
-      expectedMessage: 'Cannot read property',
+      expectedMessage: 'Cannot read properties',
     },
     {
       conditionDescription:
@@ -317,7 +317,7 @@ describe('InstagramToFlex', () => {
       expectedMessageText: 'Story mention: some fake url',
     },
   ]).test(
-    "Should return expectedStatus '$expectedMessage' when $conditionDescription",
+    "Should return $expectedStatus '$expectedMessage' when $conditionDescription",
     async ({
       event,
       expectedStatus,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/flex-plugins/pull/1114

Primary reviewer: @murilovmachado 

Tests are a WIP in this PR, but, it can still be reviewed.

## Description
This PR:
- Adds `functions/taskrouterListeners/postSurveyListener.private.ts` with logic to trigger post surveys from the taskrouter callback (instead than from Flex).
- Wraps the chat channel cleanup logic from `functions/endChat.ts` under `!featureFlags.post_survey_serverless_handled`, since this change will allow for "end chat" functionality (webchat) to still interact with the post survey.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1527)
- [WIP] New tests added

### Verification steps
See https://github.com/techmatters/flex-plugins/pull/1114.