### PR TITLE
Create a Prod Release workflow for Serverless

### DIFF
--- a/.github/actions/main-action/action.yml
+++ b/.github/actions/main-action/action.yml
@@ -143,6 +143,6 @@ runs:
       if: ${{ inputs.send-slack-message != 'false' }}
       with:
         channel-id: ${{ env.ASELO_DEPLOYS_CHANNEL_ID }}
-        slack-message: "`[Serverless]` Deployment to ${{ inputs.helpline-name }} of ref ${{ github.ref_name }} completed using workflow '${{ github.workflow }}' with SHA ${{ github.sha }} :rocket:."
+        slack-message: "`[Serverless]` Deployment to `${{ inputs.helpline-name }}` of ref `${{ github.ref_name }}` completed using workflow '${{ github.workflow }}' with SHA ${{ github.sha }} :rocket:."
       env:
         SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/actions/main-action/action.yml
+++ b/.github/actions/main-action/action.yml
@@ -143,6 +143,6 @@ runs:
       if: ${{ inputs.send-slack-message != 'false' }}
       with:
         channel-id: ${{ env.ASELO_DEPLOYS_CHANNEL_ID }}
-        slack-message: "`[Serverless]` Deployment to `${{ inputs.helpline-name }}` of ref `${{ github.ref_name }}` completed using workflow '${{ github.workflow }}' with SHA ${{ github.sha }} :rocket:."
+        slack-message: "`[Serverless]` Deployment to `${{ inputs.helpline-name }}` from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed using workflow '${{ github.workflow }}' with SHA ${{ github.sha }} :rocket:."
       env:
         SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-all-staging-accounts.yml
+++ b/.github/workflows/deploy-all-staging-accounts.yml
@@ -56,6 +56,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.14.0
         with:
           channel-id: ${{ env.ASELO_DEPLOYS_CHANNEL_ID }}
-          slack-message: "`[SERVERLESS PARALLEL DEPLOYMENT]` All Serverless Staging helplines successfully deployed :rocket:."
+          slack-message: "`[SERVERLESS PARALLEL DEPLOYMENT]` All Serverless Staging helplines successfully deployed from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` with SHA ${{ github.sha }} :rocket:."
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/serverless-pre-release-qa.yml
+++ b/.github/workflows/serverless-pre-release-qa.yml
@@ -88,6 +88,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          slack-message: "`[Serverless]` Action ${{ github.workflow }} completed with SHA ${{ github.sha }}. Release tag is ${{ steps.create_pre_release.outputs.generated-pre-release-tag }} :rocket:."
+          slack-message: "`[Serverless]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_pre_release.outputs.generated-pre-release-tag }}` :rocket:."
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/serverless-production-release.yml
+++ b/.github/workflows/serverless-production-release.yml
@@ -6,6 +6,9 @@ name: Create a production release
 on:
   workflow_dispatch:
     inputs:
+      tag-name:
+        description: Tag name - The name for the tag that will be given to this release.
+        required: true
       title:
         description: Release title - The title that will be given to this pre-release.
         required: true
@@ -22,6 +25,7 @@ jobs:
         uses: techmatters/flex-plugins/.github/actions/generate-production-release@gian_CHI-1264
         # uses: techmatters/flex-plugins/.github/actions/generate-production-release@master
         with:
+          tag-name: ${{ inputs.tag-name }}
           title: ${{ inputs.title }}
         id: create_prod_release
 

--- a/.github/workflows/serverless-production-release.yml
+++ b/.github/workflows/serverless-production-release.yml
@@ -22,8 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Create production release
-        uses: techmatters/flex-plugins/.github/actions/generate-production-release@gian_CHI-1264
-        # uses: techmatters/flex-plugins/.github/actions/generate-production-release@master
+        uses: techmatters/flex-plugins/.github/actions/generate-production-release@master
         with:
           tag-name: ${{ inputs.tag-name }}
           title: ${{ inputs.title }}

--- a/.github/workflows/serverless-production-release.yml
+++ b/.github/workflows/serverless-production-release.yml
@@ -27,11 +27,11 @@ jobs:
 
       # Send Slack notifying success
       - name: Slack aselo-deploys channel
-        uses: ./.github/actions/notify-deploys
+        uses: techmatters/flex-plugins/.github/actions/notify-deploys@master
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          slack-message: "`[Serverless]` Production Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is ${{ steps.create_prod_release.outputs.generated-release-tag }} :rocket:."
+          slack-message: "`[Serverless]` Production Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_prod_release.outputs.generated-release-tag }}` :rocket:."
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/serverless-production-release.yml
+++ b/.github/workflows/serverless-production-release.yml
@@ -1,0 +1,37 @@
+# Workflow to create a new production release from a given qa tag
+
+name: Create a production release
+
+# Controls when the action will run.
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: Release title - The title that will be given to this pre-release.
+        required: true
+
+jobs:
+  generate-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Create production release
+        uses: techmatters/flex-plugins/.github/actions/generate-production-release@gian_CHI-1264
+        # uses: techmatters/flex-plugins/.github/actions/generate-production-release@master
+        with:
+          title: ${{ inputs.title }}
+        id: create_prod_release
+
+      # Send Slack notifying success
+      # - name: Slack aselo-deploys channel
+      #   uses: ./.github/actions/notify-deploys
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      #     slack-message: "`[Serverless]` Production Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is ${{ steps.create_prod_release.outputs.generated-release-tag }} :rocket:."
+      #   env:
+      #     SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/serverless-production-release.yml
+++ b/.github/workflows/serverless-production-release.yml
@@ -26,12 +26,12 @@ jobs:
         id: create_prod_release
 
       # Send Slack notifying success
-      # - name: Slack aselo-deploys channel
-      #   uses: ./.github/actions/notify-deploys
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      #     slack-message: "`[Serverless]` Production Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is ${{ steps.create_prod_release.outputs.generated-release-tag }} :rocket:."
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
+      - name: Slack aselo-deploys channel
+        uses: ./.github/actions/notify-deploys
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          slack-message: "`[Serverless]` Production Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is ${{ steps.create_prod_release.outputs.generated-release-tag }} :rocket:."
+        env:
+          SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/release-notes/v1.5.0.md
+++ b/release-notes/v1.5.0.md
@@ -1,8 +1,0 @@
-# Big Title
-Testing body files
-
-Here we'll include the description
-
-> Can quote
-
-[Can add links](https://github.com/techmatters/serverless/pull/385)

--- a/release-notes/v1.5.0.md
+++ b/release-notes/v1.5.0.md
@@ -1,0 +1,8 @@
+# Big Title
+Testing body files
+
+Here we'll include the description
+
+> Can quote
+
+[Can add links](https://github.com/techmatters/serverless/pull/385)


### PR DESCRIPTION
NOTE: review after https://github.com/techmatters/flex-plugins/pull/1147. Any change in that PR will also affect the behavior of this one.

## Description
Similarly to https://github.com/techmatters/flex-plugins/pull/1147, this PR adds a new workflow to create Production Releases. It entirely reuses the action introduced in the linked PR (`flex-plugins` repo), so we'll have a central place for this action, same as with most of our shared actions.

This action expects
- To be called with a `tag` ref.
- Takes as an input a `tag-name` for the release.
- Takes as an input a `title` for the release.

If the workflow succeeds, it will create anew tag and a release for it, with the provided `tag-name` and `title` and a body with the text "TO-DO".

This PR shares the [possible failures](https://github.com/techmatters/flex-plugins/pull/1147#:~:text=This%20workflow%20will%20fail%20if%3A) with the linked PR.
Please refer to the original PR to get the entire details about the underlying action being used here.

I manually created a [QA tag and pre-release for version v1.5.0, called v1.5.0-qa.2](https://github.com/techmatters/serverless/releases/tag/v1.5.0-qa.2). This tag is fixed to commit https://github.com/techmatters/serverless/commit/bb3fc080e903191b5bb8ebd9bcc811439111efc7 (which is a commit within this branch). The result of [running the newly introduced workflow using above tag (`v1.5.0-qa.2`) as the ref, `v1.5.0` as the `tag-name` input and `"Test"` as the `title` input](https://github.com/techmatters/serverless/actions/runs/3884369775/jobs/6626843035) is [the following release](https://github.com/techmatters/serverless/releases/tag/v1.5.0).

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1265)
- [n/a] New tests added

### Verification steps
Checking execution of this workflow linked above should give an idea of what to expect from it. You can also try running it via curl like
```
curl \                                                                                                         
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR GH TOKEN>"\  
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/techmatters/serverless/actions/workflows/serverless-production-release.yml/dispatches \
  -d '{"ref":"vX.Y.Z-qa.N","inputs":{"title":"A title for the release", "tag-name": "vX.Y.Z"}}'
```
where `vX.Y.Z-qa.N` is a valid tag. Note that until this is merged against master, you must manually create the test QA tags from this branch (or the workflow won't exist in the given commit), or merging this branch against another one that you'd like to test.