### PR TITLE
CHI-1484: Allow self signed certs when sending self reported CSAM (temporary). …

### DIFF
--- a/.github/actions/custom-actions/aselo_development_custom/action.yml
+++ b/.github/actions/custom-actions/aselo_development_custom/action.yml
@@ -34,17 +34,17 @@ runs:
       uses: "marvinpinto/action-inject-ssm-secrets@latest"
       with:
         ssm_parameter: "AS_DEV_IWF_SECRET_KEY"
-        env_variable_name: "AS_DEV_IWF_SECRET_KEY"
+        env_variable_name: "IWF_SECRET_KEY"
     - name: Set AS_DEV_IWF_API_CASE_URL
       uses: "marvinpinto/action-inject-ssm-secrets@latest"
       with:
         ssm_parameter: "AS_DEV_IWF_API_CASE_URL"
-        env_variable_name: "AS_DEV_IWF_API_CASE_URL"
+        env_variable_name: "IWF_API_CASE_URL"
     - name: Set AS_DEV_IWF_REPORT_URL
       uses: "marvinpinto/action-inject-ssm-secrets@latest"
       with:
         ssm_parameter: "AS_DEV_IWF_REPORT_URL"
-        env_variable_name: "AS_DEV_IWF_REPORT_URL"
+        env_variable_name: "IWF_REPORT_URL"
 
     - name: Set Aselo Twitter Consumer Key
       uses: "marvinpinto/action-inject-ssm-secrets@latest"

--- a/tests/selfReportToIWF.test.ts
+++ b/tests/selfReportToIWF.test.ts
@@ -21,9 +21,9 @@ jest.mock('axios');
 const baseContext = {
   getTwilioClient: (): any => ({}),
   DOMAIN_NAME: 'serverless',
-  AS_DEV_IWF_API_CASE_URL: 'AS_DEV_IWF_API_CASE_URL',
-  AS_DEV_IWF_REPORT_URL: 'AS_DEV_IWF_REPORT_URL',
-  AS_DEV_IWF_SECRET_KEY: 'AS_DEV_IWF_SECRET_KEY',
+  IWF_API_CASE_URL: 'TEST_IWF_API_CASE_URL',
+  IWF_REPORT_URL: 'TEST_IWF_REPORT_URL',
+  IWF_SECRET_KEY: 'TEST_IWF_SECRET_KEY',
   PATH: 'PATH',
   SERVICE_SID: undefined,
   ENVIRONMENT_SID: undefined,
@@ -87,7 +87,7 @@ describe('selfReportToIWF', () => {
     await selfReportToIWF(baseContext, event, callback);
   });
 
-  test('Should POST a payload to AS_DEV_IWF_API_CASE_URL and return 200', async () => {
+  test('Should POST a payload to TEST_IWF_API_CASE_URL and return 200', async () => {
     const event: Body = {
       user_age_range: '13-15',
       case_number: 'case_number',
@@ -108,7 +108,7 @@ describe('selfReportToIWF', () => {
 
     expect(axios).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: baseContext.AS_DEV_IWF_API_CASE_URL,
+        url: baseContext.IWF_API_CASE_URL,
         method: 'POST',
         data: formData,
       }),
@@ -142,9 +142,9 @@ describe('selfReportToIWF', () => {
     await selfReportToIWF(
       {
         ...baseContext,
-        AS_DEV_IWF_API_CASE_URL: 'AS_DEV_IWF_API_CASE_URL',
-        AS_DEV_IWF_REPORT_URL: 'AS_DEV_IWF_REPORT_URL',
-        AS_DEV_IWF_SECRET_KEY: 'AS_DEV_IWF_SECRET_KEY',
+        IWF_API_CASE_URL: 'TEST_IWF_API_CASE_URL',
+        IWF_REPORT_URL: 'TEST_IWF_REPORT_URL',
+        IWF_SECRET_KEY: 'TEST_IWF_SECRET_KEY',
       },
       event,
       () => {},
@@ -152,7 +152,7 @@ describe('selfReportToIWF', () => {
 
     expect(axios).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: baseContext.AS_DEV_IWF_API_CASE_URL,
+        url: baseContext.IWF_API_CASE_URL,
         method: 'POST',
         data: formData,
       }),


### PR DESCRIPTION
## Description

IWF are using a self signed TLS certificate on their test server. In order to test the feature this will temporarily reconfigure the HTTP client in `/selfReportToIWF` to accept self signed certs

* Allow self signed certs when sending self reported CSAM (temporary).
* Rename IWF env vars to remove account details


### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added



### Related Issues
CHI-1484

### Verification steps

* Deploy serverless to Aselo Development
* Send a CSAM report, the HTTP client should accept the IWF test server's self signed cert
