### PR TITLE
CHI-1484: Fix form data stream state in selfReportIwf

### DIFF
--- a/functions/selfReportToIWF.ts
+++ b/functions/selfReportToIWF.ts
@@ -31,8 +31,6 @@ export type Body = {
   request: { cookies: {}; headers: {} };
 };
 
-export const formData = new FormData();
-
 export const handler = TokenValidator(
   async (
     context: Context<EnvVars>,
@@ -51,7 +49,7 @@ export const handler = TokenValidator(
         case_number,
         user_age_range,
       };
-
+      const formData = new FormData();
       formData.append('secret_key', body.secret_key);
       formData.append('case_number', body.case_number);
       formData.append('user_age_range', body.user_age_range);


### PR DESCRIPTION
## Description

An issue was occurring where requests were 'hanging' after the first one sometimes for selfReportIWF
This was because the 'FormData' instance used by the function was defined externally. 'FormData' is a stream buffer intended for a single use in a single request. 

It being defined externally resulted in situations where requests were trying to reuse a closed stream and hanging

* Move form data variable inside function scope
* Fix tests

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
Fixes CHI-1484

### Verification steps

Deploy the fix & regression test self reported CSAM
