### PR TITLE
CHI-1657: Disable operating hours checks for non prod builds by default

### DIFF
--- a/.github/actions/custom-actions/teguio_staging_custom/action.yml
+++ b/.github/actions/custom-actions/teguio_staging_custom/action.yml
@@ -63,7 +63,6 @@ runs:
       run: echo "TWITTER_FLEX_FLOW_SID=${{ env.TWITTER_FLEX_FLOW_SID }}" >> .env
       shell: bash
 
-    # Append environment variables
     - name: Add FACEBOOK_APP_SECRET
       run: echo "FACEBOOK_APP_SECRET=${{ env.FACEBOOK_APP_SECRET }}" >> .env
       shell: bash

--- a/.github/actions/main-action/action.yml
+++ b/.github/actions/main-action/action.yml
@@ -111,7 +111,7 @@ runs:
           DISABLE_OPERATING_HOURS_CHECK=true
           EOT
       shell: bash
-      if: inputs.disable_operating_hours == 'true'
+      if: ${{ inputs.disable_operating_hours == 'true' }}
 
     # Run custom action to perform per-helpline based actions
     - name: Execute custom action (if any)

--- a/.github/actions/main-action/action.yml
+++ b/.github/actions/main-action/action.yml
@@ -100,6 +100,15 @@ runs:
           TWILIO_SERVERLESS_API_CONCURRENCY=1
           EOT
       shell: bash
+      # Can be overridden in custom action
+    - name: Disable Operating Hours for staging
+      run: |
+          cat <<EOT >> .env
+          DISABLE_OPERATING_HOURS_CHECK=true
+          EOT
+      shell: bash
+      if: inputs.disable_operating_hours == 'true'
+
     # Run custom action to perform per-helpline based actions
     - name: Execute custom action (if any)
       uses: ./.github/actions/custom-actions

--- a/.github/actions/main-action/action.yml
+++ b/.github/actions/main-action/action.yml
@@ -111,7 +111,7 @@ runs:
           DISABLE_OPERATING_HOURS_CHECK=true
           EOT
       shell: bash
-      if: ${{ inputs.disable_operating_hours == 'true' }}
+      if: ${{ inputs.disable-operating-hours == 'true' }}
 
     # Run custom action to perform per-helpline based actions
     - name: Execute custom action (if any)

--- a/.github/actions/main-action/action.yml
+++ b/.github/actions/main-action/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: 'Specifies if should send a Slack message at the end of successful run. Defaults to true'
     required: false
     default: 'true'
+  disable-operating-hours:
+    description: 'Specifies if we should disable enforcement of operating hours (uuseful for non production accounts). Defaults to false'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/aarambh_production.yml
+++ b/.github/workflows/aarambh_production.yml
@@ -5,13 +5,10 @@ name: Aarambh Production release
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "IN"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "IN"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/aarambh_production.yml
+++ b/.github/workflows/aarambh_production.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "IN"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "IN"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/aarambh_staging.yml
+++ b/.github/workflows/aarambh_staging.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "IN"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "IN"
+          environment_code: "STG"
+          changelog: "Deploying individual account"
        

--- a/.github/workflows/aarambh_staging.yml
+++ b/.github/workflows/aarambh_staging.yml
@@ -6,14 +6,11 @@ name: Aarambh Staging release
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "IN"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "IN"
+      environment_code: "STG"
+      changelog: "Deploying individual account"
        

--- a/.github/workflows/aselo_beta.yml
+++ b/.github/workflows/aselo_beta.yml
@@ -1,6 +1,4 @@
-# This is a basic workflow to publish a Twilio function with Github Actions
-
-name: Aselo Beta release
+name: Aselo Beta deploy
 
 on:
   workflow_dispatch
@@ -9,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "AS"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "AS"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/aselo_beta.yml
+++ b/.github/workflows/aselo_beta.yml
@@ -3,13 +3,10 @@ name: Aselo Beta deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "AS"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "AS"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -2,7 +2,6 @@
 
 name: Aselo Development release
 
-
 on:
   workflow_dispatch
 jobs:

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -6,13 +6,10 @@ name: Aselo Development release
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "AS"
-          environment_code: "DEV"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "AS"
+      environment_code: "DEV"
+      changelog: "Deploying individual account"

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "AS"
-        environment_code: "DEV"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "AS"
+          environment_code: "DEV"
+          changelog: "Deploying individual account"

--- a/.github/workflows/aselo_production.yml
+++ b/.github/workflows/aselo_production.yml
@@ -5,13 +5,10 @@ name: Aselo Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "AS"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "AS"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/aselo_production.yml
+++ b/.github/workflows/aselo_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Aselo Production release
+name: Aselo Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "AS"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "AS"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/canada_staging.yml
+++ b/.github/workflows/canada_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Kids Help Phone Staging release
+name: Kids Help Phone Staging deploy
 
 
 on:
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "CA"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "CA"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/canada_staging.yml
+++ b/.github/workflows/canada_staging.yml
@@ -6,13 +6,10 @@ name: Kids Help Phone Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "CA"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "CA"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/cl_linealibre_production.yml
+++ b/.github/workflows/cl_linealibre_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Línea Libre Helpline (CL) Production release
+name: Línea Libre Helpline (CL) Production deploy
 
 
 on:
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "CL"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "CL"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/cl_linealibre_production.yml
+++ b/.github/workflows/cl_linealibre_production.yml
@@ -6,13 +6,10 @@ name: Línea Libre Helpline (CL) Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "CL"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "CL"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/cl_linealibre_staging.yml
+++ b/.github/workflows/cl_linealibre_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Línea Libre Helpline (CL) Staging release
+name: Línea Libre Helpline (CL) Staging deploy
 
 
 on:
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "CL"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "CL"
+          environment_code: "STG"
+          changelog: "Deploying individual account"
       
        

--- a/.github/workflows/cl_linealibre_staging.yml
+++ b/.github/workflows/cl_linealibre_staging.yml
@@ -6,15 +6,12 @@ name: Línea Libre Helpline (CL) Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "CL"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "CL"
+      environment_code: "STG"
+      changelog: "Deploying individual account"
       
        

--- a/.github/workflows/custom_helpline.yml
+++ b/.github/workflows/custom_helpline.yml
@@ -15,6 +15,8 @@ on:
       environment_code:
         description: The short upper case code used to identify the environment internally, e.g. STG, PROD, DEV
         required: true
+      force_enable_operating_hours:
+        description: Forces operating hours to be enforced for this deployment (by default they are only enforced in PROD)
   workflow_call:
     inputs:
       helpline_code:
@@ -146,3 +148,4 @@ jobs:
           aws-region: $AWS_REGION
           s3-bucket: $S3_BUCKET
           helpline-name: ${{inputs.helpline_code}}_${{inputs.environment_code}}
+          disable-operating-hours: ${{ (inputs.force_enable_operating_hours || inputs.environment_code == 'PROD') && 'false' || 'true' }}

--- a/.github/workflows/custom_helpline.yml
+++ b/.github/workflows/custom_helpline.yml
@@ -16,6 +16,7 @@ on:
         description: The short upper case code used to identify the environment internally, e.g. STG, PROD, DEV
         required: true
       force_enable_operating_hours:
+        type: boolean
         description: Forces operating hours to be enforced for this deployment (by default they are only enforced in PROD)
   workflow_call:
     inputs:

--- a/.github/workflows/custom_helpline.yml
+++ b/.github/workflows/custom_helpline.yml
@@ -149,4 +149,5 @@ jobs:
           aws-region: $AWS_REGION
           s3-bucket: $S3_BUCKET
           helpline-name: ${{inputs.helpline_code}}_${{inputs.environment_code}}
+          # Set 'false' if the target environment is production OR the 'force_enable_operating_hours' override option is checked - otherwise 'true'
           disable-operating-hours: ${{ (inputs.force_enable_operating_hours || inputs.environment_code == 'PROD') && 'false' || 'true' }}

--- a/.github/workflows/deploy_development_e2e_end_to_end.yml
+++ b/.github/workflows/deploy_development_e2e_end_to_end.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "E2E"
-        environment_code: "DEV"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "E2E"
+          environment_code: "DEV"
+          changelog: "Deploying individual account"

--- a/.github/workflows/deploy_development_e2e_end_to_end.yml
+++ b/.github/workflows/deploy_development_e2e_end_to_end.yml
@@ -4,13 +4,10 @@ name: Deploy Development (E2E) End to End
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "E2E"
-          environment_code: "DEV"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "E2E"
+      environment_code: "DEV"
+      changelog: "Deploying individual account"

--- a/.github/workflows/ecpat_philippines_production.yml
+++ b/.github/workflows/ecpat_philippines_production.yml
@@ -6,13 +6,10 @@ name: ECPAT Phillippines Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "PH"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "PH"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/ecpat_philippines_production.yml
+++ b/.github/workflows/ecpat_philippines_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: ECPAT Phillippines Production release
+name: ECPAT Phillippines Production deploy
 
 
 on:
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "PH"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "PH"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/ecpat_philippines_staging.yml
+++ b/.github/workflows/ecpat_philippines_staging.yml
@@ -6,12 +6,9 @@ on:
   workflow_dispatch
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "PH"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "PH"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/ecpat_philippines_staging.yml
+++ b/.github/workflows/ecpat_philippines_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: ECPAT Philippines Staging release
+name: ECPAT Philippines Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "PH"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "PH"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/ethiopia_production.yml
+++ b/.github/workflows/ethiopia_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Ethiopia Production release
+name: Ethiopia Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ET"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ET"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/ethiopia_production.yml
+++ b/.github/workflows/ethiopia_production.yml
@@ -5,13 +5,10 @@ name: Ethiopia Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ET"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ET"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/ethiopia_staging.yml
+++ b/.github/workflows/ethiopia_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Ethiopia Staging release
+name: Ethiopia Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ET"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ET"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/ethiopia_staging.yml
+++ b/.github/workflows/ethiopia_staging.yml
@@ -5,13 +5,10 @@ name: Ethiopia Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ET"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ET"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/flex2_staging.yml
+++ b/.github/workflows/flex2_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Flex 2.0 Staging release
+name: Flex 2.0 Staging deplioy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "F2"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "F2"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/flex2_staging.yml
+++ b/.github/workflows/flex2_staging.yml
@@ -5,13 +5,10 @@ name: Flex 2.0 Staging deplioy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "F2"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "F2"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/hungary_production.yml
+++ b/.github/workflows/hungary_production.yml
@@ -5,13 +5,10 @@ name: Kek Vonal Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "HU"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "HU"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/hungary_production.yml
+++ b/.github/workflows/hungary_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Kek Vonal Production release
+name: Kek Vonal Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "HU"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "HU"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/hungary_staging.yml
+++ b/.github/workflows/hungary_staging.yml
@@ -5,13 +5,10 @@ name: Kek Vonal Staging release
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "HU"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "HU"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/hungary_staging.yml
+++ b/.github/workflows/hungary_staging.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "HU"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "HU"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/jamaica_production.yml
+++ b/.github/workflows/jamaica_production.yml
@@ -5,13 +5,10 @@ name: SafeSpot Production release
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "JM"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "JM"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/jamaica_production.yml
+++ b/.github/workflows/jamaica_production.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "JM"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "JM"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/jamaica_staging.yml
+++ b/.github/workflows/jamaica_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: SafeSpot Staging release
+name: SafeSpot Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "JM"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "JM"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/jamaica_staging.yml
+++ b/.github/workflows/jamaica_staging.yml
@@ -5,13 +5,10 @@ name: SafeSpot Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "JM"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "JM"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/kellimni_production.yml
+++ b/.github/workflows/kellimni_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Kellimni Production release
+name: Kellimni Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "MT"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "MT"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/kellimni_production.yml
+++ b/.github/workflows/kellimni_production.yml
@@ -5,13 +5,10 @@ name: Kellimni Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "MT"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "MT"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/kellimni_staging.yml
+++ b/.github/workflows/kellimni_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Kellimni Staging release
+name: Kellimni Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "MT"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "MT"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/kellimni_staging.yml
+++ b/.github/workflows/kellimni_staging.yml
@@ -5,13 +5,10 @@ name: Kellimni Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "MT"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "MT"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/malawi_production.yml
+++ b/.github/workflows/malawi_production.yml
@@ -6,12 +6,9 @@ on:
   workflow_dispatch
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "MW"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "MW"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/malawi_production.yml
+++ b/.github/workflows/malawi_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Malawi Production release
+name: Malawi Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "MW"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "MW"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/malawi_staging.yml
+++ b/.github/workflows/malawi_staging.yml
@@ -5,13 +5,10 @@ name: Malawi Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "MW"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "MW"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/malawi_staging.yml
+++ b/.github/workflows/malawi_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Malawi Staging release
+name: Malawi Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "MW"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "MW"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/romania_staging.yml
+++ b/.github/workflows/romania_staging.yml
@@ -5,13 +5,10 @@ name: Telefonul Copilului (Romania) Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "RO"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "RO"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/romania_staging.yml
+++ b/.github/workflows/romania_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Telefonul Copilului (Romania) Staging release
+name: Telefonul Copilului (Romania) Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "RO"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "RO"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/safernet_production.yml
+++ b/.github/workflows/safernet_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: SaferNet Production release
+name: SaferNet Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "BR"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "BR"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/safernet_production.yml
+++ b/.github/workflows/safernet_production.yml
@@ -5,13 +5,10 @@ name: SaferNet Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "BR"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "BR"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/safernet_staging.yml
+++ b/.github/workflows/safernet_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Safernet Staging release
+name: Safernet Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "BR"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "BR"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/safernet_staging.yml
+++ b/.github/workflows/safernet_staging.yml
@@ -5,13 +5,10 @@ name: Safernet Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "BR"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "BR"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/south_africa_production.yml
+++ b/.github/workflows/south_africa_production.yml
@@ -5,13 +5,10 @@ name: South Africa Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ZA"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ZA"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/south_africa_production.yml
+++ b/.github/workflows/south_africa_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: South Africa Production release
+name: South Africa Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ZA"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ZA"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/south_africa_staging.yml
+++ b/.github/workflows/south_africa_staging.yml
@@ -5,13 +5,10 @@ name: South Africa Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ZA"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ZA"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/south_africa_staging.yml
+++ b/.github/workflows/south_africa_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: South Africa Staging release
+name: South Africa Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ZA"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ZA"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/teguio_colombia_production.yml
+++ b/.github/workflows/teguio_colombia_production.yml
@@ -5,13 +5,10 @@ name: Te Guío Colombia Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "CO"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "CO"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/teguio_colombia_production.yml
+++ b/.github/workflows/teguio_colombia_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Te Guío Colombia Production release
+name: Te Guío Colombia Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "CO"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "CO"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/teguio_colombia_staging.yml
+++ b/.github/workflows/teguio_colombia_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Te Guio Colombia Staging release
+name: Te Guio Colombia Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "CO"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "CO"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/teguio_colombia_staging.yml
+++ b/.github/workflows/teguio_colombia_staging.yml
@@ -5,13 +5,10 @@ name: Te Guio Colombia Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "CO"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "CO"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/telefonzaufania_pl_staging.yml
+++ b/.github/workflows/telefonzaufania_pl_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Telefon Zaufania (PL) Staging release
+name: Telefon Zaufania (PL) Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "PL"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "PL"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/telefonzaufania_pl_staging.yml
+++ b/.github/workflows/telefonzaufania_pl_staging.yml
@@ -5,13 +5,10 @@ name: Telefon Zaufania (PL) Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "PL"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "PL"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/thailand_production.yml
+++ b/.github/workflows/thailand_production.yml
@@ -5,13 +5,10 @@ name: Thailand Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "TH_PROD"
-          environment_code: "DEV"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "TH_PROD"
+      environment_code: "DEV"
+      changelog: "Deploying individual account"

--- a/.github/workflows/thailand_production.yml
+++ b/.github/workflows/thailand_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Thailand Production release
+name: Thailand Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "TH_PROD"
-        environment_code: "DEV"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "TH_PROD"
+          environment_code: "DEV"
+          changelog: "Deploying individual account"

--- a/.github/workflows/thailand_staging.yml
+++ b/.github/workflows/thailand_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Thailand Staging release
+name: Thailand Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "TH"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "TH"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/thailand_staging.yml
+++ b/.github/workflows/thailand_staging.yml
@@ -5,13 +5,10 @@ name: Thailand Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "TH"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "TH"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/uk_staging.yml
+++ b/.github/workflows/uk_staging.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "UK"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "UK"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/uk_staging.yml
+++ b/.github/workflows/uk_staging.yml
@@ -5,13 +5,10 @@ name: Revenge Porn Helpline Staging release
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "UK"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "UK"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/zambia_production.yml
+++ b/.github/workflows/zambia_production.yml
@@ -5,13 +5,10 @@ name: Zambia Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ZM"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ZM"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/zambia_production.yml
+++ b/.github/workflows/zambia_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Zambia Production release
+name: Zambia Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ZM"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ZM"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Zambia Staging release
+name: Zambia Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ZM"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ZM"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -5,13 +5,10 @@ name: Zambia Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ZM"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ZM"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/.github/workflows/zimbabwe_production.yml
+++ b/.github/workflows/zimbabwe_production.yml
@@ -5,13 +5,10 @@ name: Childline Zimbabwe Production deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ZW"
-          environment_code: "PROD"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ZW"
+      environment_code: "PROD"
+      changelog: "Deploying individual account"

--- a/.github/workflows/zimbabwe_production.yml
+++ b/.github/workflows/zimbabwe_production.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Childline Zimbabwe Production release
+name: Childline Zimbabwe Production deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ZW"
-        environment_code: "PROD"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ZW"
+          environment_code: "PROD"
+          changelog: "Deploying individual account"

--- a/.github/workflows/zimbabwe_staging.yml
+++ b/.github/workflows/zimbabwe_staging.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to publish a Twilio function with Github Actions
 
-name: Childline Zimbabwe Staging release
+name: Childline Zimbabwe Staging deploy
 
 on:
   workflow_dispatch
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: ./.github/workflows/custom_helpline.yml
-      secrets: inherit
-      with:
-        helpline_code: "ZW"
-        environment_code: "STG"
-        changelog: "Deploying individual account"
+      - uses: ./.github/workflows/custom_helpline.yml
+        secrets: inherit
+        with:
+          helpline_code: "ZW"
+          environment_code: "STG"
+          changelog: "Deploying individual account"

--- a/.github/workflows/zimbabwe_staging.yml
+++ b/.github/workflows/zimbabwe_staging.yml
@@ -5,13 +5,10 @@ name: Childline Zimbabwe Staging deploy
 on:
   workflow_dispatch
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: ./.github/workflows/custom_helpline.yml
-        secrets: inherit
-        with:
-          helpline_code: "ZW"
-          environment_code: "STG"
-          changelog: "Deploying individual account"
+  deploy:
+    uses: ./.github/workflows/custom_helpline.yml
+    secrets: inherit
+    with:
+      helpline_code: "ZW"
+      environment_code: "STG"
+      changelog: "Deploying individual account"

--- a/functions/operatingHours.ts
+++ b/functions/operatingHours.ts
@@ -36,6 +36,7 @@ type OperatingInfo = OfficeOperatingInfo & {
 
 type EnvVars = {
   OPERATING_INFO_KEY: string;
+  DISABLE_OPERATING_HOURS_CHECK: string;
 };
 
 export type Body = {
@@ -106,7 +107,11 @@ export const handler = async (
   const resolve = bindResolve(callback)(response);
 
   try {
-    const { OPERATING_INFO_KEY } = context;
+    const { OPERATING_INFO_KEY, DISABLE_OPERATING_HOURS_CHECK } = context;
+
+    if (DISABLE_OPERATING_HOURS_CHECK?.toLowerCase() === 'true') {
+      resolve(success('open'));
+    }
 
     if (!OPERATING_INFO_KEY) throw new Error('OPERATING_INFO_KEY env var not provided.');
 

--- a/tests/operatingHours.test.ts
+++ b/tests/operatingHours.test.ts
@@ -13,6 +13,7 @@ const baseContext = {
   PATH: 'PATH',
   SERVICE_SID: undefined,
   ENVIRONMENT_SID: undefined,
+  DISABLE_OPERATING_HOURS_CHECK: '',
 };
 
 const testday = 1617911935784; // timeOfDay: 21:58, dayOfWeek: 4, currentDate: '04/08/2021'
@@ -242,6 +243,24 @@ describe('operatingHours', () => {
       };
 
       await operatingHours(baseContext, event, callback);
+    });
+
+    test('DISABLE_OPERATING_HOURS_CHECK, return open', async () => {
+      const event: Body = { channel: 'webchat', office: 'office1' };
+
+      const callback: ServerlessCallback = (err, result) => {
+        expect(result).toBeDefined();
+        const response = result as MockedResponse;
+        console.log('>>>>>>', response.getBody());
+        expect(response.getStatus()).toBe(200);
+        expect(response.getBody()).toContain('open');
+      };
+
+      await operatingHours(
+        { ...baseContext, DISABLE_OPERATING_HOURS_CHECK: 'true' },
+        event,
+        callback,
+      );
     });
   });
 });


### PR DESCRIPTION
Note: this was kind of a 'rage PR' that I raised after the staging helpline I was trying to debug refused to let me initiate a webchat because it was 'closed for the day'

So it may not be implemented in the most optimal manner, appreciate your input!

## Description

It is extremely frustrating trying to debug an account specific issue in staging only to be blocked out of chat by an operating hours restriction. Operating hours should not be enforced by default for non production builds, only when you want to test that particular functionality

* Disable operating hours checks for non prod builds by default
* With an override option

### Checklist
- [ ] Corresponding issue has been opened
- N/A New tests added


### Related Issues
CHI-1657

### Verification steps

* Deploy a staging build, check that the channels can be used out of hours
* Deploy a staging build with the override checked, ensure operating hours are enforced
* Deploy a prod build without the override checked, ensure operating hours are enforced
