### PR TITLE
CHI-1646: Incoming Instagram Story Replies are ignored

### DIFF
--- a/tests/webhooks/instagram/InstagramToFlex.test.ts
+++ b/tests/webhooks/instagram/InstagramToFlex.test.ts
@@ -305,6 +305,51 @@ describe('InstagramToFlex', () => {
       expectedToCreateChannel: undefined,
     },
     {
+      conditionDescription: 'story reply',
+      event: {
+        ...validEventBody(),
+        entry: [
+          {
+            ...validEventBody().entry[0],
+            messaging: [
+              {
+                ...validEventBody().entry[0].messaging[0],
+                message: {
+                  ...validEventBody().entry[0].messaging[0].message,
+                  reply_to: { story: { url: '', id: '' } },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      expectedStatus: 200,
+      expectedMessage: 'Ignored story reply.',
+    },
+    {
+      conditionDescription: 'inline reply',
+      event: {
+        ...validEventBody(),
+        entry: [
+          {
+            ...validEventBody().entry[0],
+            messaging: [
+              {
+                ...validEventBody().entry[0].messaging[0],
+                message: {
+                  ...validEventBody().entry[0].messaging[0].message,
+                  reply_to: { mid: '' },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      expectedStatus: 200,
+      expectedMessage: `Message sent in channel ${MOCK_SENDER_CHANNEL_SID}.`,
+      expectedToBeSentOnChannel: MOCK_SENDER_CHANNEL_SID,
+    },
+    {
       conditionDescription: 'story tagging from an inactive conversation',
       event: validEventBody({
         senderId: 'sender_id',


### PR DESCRIPTION
**Description**

Any message sent to the InstagramToFlex function identified as being a reply to a story will no longer be forwarded on to Flex

[X] Tests Added
[X] Issue Created

Issue:

CHI-1646

Validation Steps:

Not sure, never used Instagram before, I hope @dee-lou will know