### PR TITLE
CHI-1484: Remove option to ignore self signed certs when validating TLS certs for IWF self reporting

### DIFF
--- a/.github/actions/custom-actions/aarambh_staging_custom/action.yml
+++ b/.github/actions/custom-actions/aarambh_staging_custom/action.yml
@@ -57,6 +57,3 @@ runs:
     - name: Add IWF_REPORT_URL
       run: echo "IWF_REPORT_URL=${{ env.IWF_REPORT_URL }}" >> .env
       shell: bash
-    - name: Add IWF_REPORT_SELF_SIGNED
-      run: echo "IWF_REPORT_SELF_SIGNED=true" >> .env
-      shell: bash

--- a/.github/actions/custom-actions/aselo_development_custom/action.yml
+++ b/.github/actions/custom-actions/aselo_development_custom/action.yml
@@ -126,9 +126,6 @@ runs:
     - name: Add IWF_REPORT_URL
       run: echo "IWF_REPORT_URL=${{ env.IWF_REPORT_URL }}" >> .env
       shell: bash
-    - name: Add IWF_REPORT_SELF_SIGNED
-      run: echo "IWF_REPORT_SELF_SIGNED=true" >> .env
-      shell: bash
 
     - name: Add TWITTER_CONSUMER_KEY
       run: echo "TWITTER_CONSUMER_KEY=${{ env.TWITTER_CONSUMER_KEY }}" >> .env

--- a/functions/selfReportToIWF.ts
+++ b/functions/selfReportToIWF.ts
@@ -10,13 +10,10 @@ import {
   functionValidator as TokenValidator,
 } from '@tech-matters/serverless-helpers';
 
-const https = require('https');
-
 type EnvVars = {
   IWF_API_CASE_URL: string;
   IWF_REPORT_URL: string;
   IWF_SECRET_KEY: string;
-  IWF_REPORT_SELF_SIGNED: string;
 };
 
 export type IWFSelfReportPayload = {
@@ -63,17 +60,6 @@ export const handler = TokenValidator(
         data: formData,
         validateStatus: () => true,
       };
-
-      if (
-        context.IWF_REPORT_SELF_SIGNED &&
-        context.IWF_REPORT_SELF_SIGNED.toLowerCase() === 'true'
-      ) {
-        config.httpsAgent = new https.Agent({
-          // This is a TEMPORARY workaround to allow testing whilst the IWF test server users a self signed TLS cert
-          // Do not deploy to production
-          rejectUnauthorized: false,
-        });
-      }
 
       const report = await axios(config);
 

--- a/tests/selfReportToIWF.test.ts
+++ b/tests/selfReportToIWF.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-var */
 import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import axios from 'axios';
 import {
   Body,
   handler as selfReportToIWF,

--- a/tests/selfReportToIWF.test.ts
+++ b/tests/selfReportToIWF.test.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-var */
 import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
-import axios, { AxiosRequestConfig } from 'axios';
-import * as https from 'https';
 import {
   Body,
   handler as selfReportToIWF,
@@ -34,7 +32,6 @@ const baseContext = {
   IWF_API_CASE_URL: 'TEST_IWF_API_CASE_URL',
   IWF_REPORT_URL: 'TEST_IWF_REPORT_URL',
   IWF_SECRET_KEY: 'TEST_IWF_SECRET_KEY',
-  IWF_REPORT_SELF_SIGNED: '',
   PATH: 'PATH',
   SERVICE_SID: undefined,
   ENVIRONMENT_SID: undefined,
@@ -114,28 +111,6 @@ describe('selfReportToIWF', () => {
         data: expect.objectContaining(expectedFormData),
       }),
     );
-
-    const iwfPayload = (axios as unknown as jest.Mock).mock.calls[0][0] as AxiosRequestConfig;
-    // Can be removed once we deprecate the temporary 'allow self signed option'
-    expect(iwfPayload.httpsAgent).not.toBeDefined();
-  });
-
-  test('Should set https axios property if self signed set to true', async () => {
-    const event: Body = {
-      user_age_range: '13-15',
-      case_number: 'case_number',
-      request: { cookies: {}, headers: {} },
-    };
-
-    await selfReportToIWF({ ...baseContext, IWF_REPORT_SELF_SIGNED: 'true' }, event, () => {});
-
-    expect(axios).toHaveBeenCalledWith(
-      expect.objectContaining({
-        httpsAgent: expect.any(https.Agent),
-      }),
-    );
-    const iwfPayload = (axios as unknown as jest.Mock).mock.calls[0][0] as AxiosRequestConfig;
-    expect((iwfPayload.httpsAgent as https.Agent).options.rejectUnauthorized).toBe(false);
   });
 
   test('Environment variables should override default values in POST', async () => {


### PR DESCRIPTION
**Description**

IWF have fixed the cert issue on their test server sothis insecure option is no longer needed

**Issue:**
CHI-1484

**Validation Steps:**

Redeploy and check self reported CSAM feature still works on Aselo Development or RATI