### PR TITLE
Fix IWF Self-Gen URL generator format

### DIFF
--- a/functions/selfReportToIWF.ts
+++ b/functions/selfReportToIWF.ts
@@ -65,7 +65,7 @@ export const handler = TokenValidator(
 
       if (report.data?.result !== 'OK') return resolve(error400(report.data?.message));
 
-      const reportUrl = `${context.IWF_REPORT_URL}/t?=${report.data?.message?.access_token}`;
+      const reportUrl = `${context.IWF_REPORT_URL}/?t=${report.data?.message?.access_token}`;
 
       const data = {
         reportUrl,

--- a/tests/selfReportToIWF.test.ts
+++ b/tests/selfReportToIWF.test.ts
@@ -103,7 +103,28 @@ describe('selfReportToIWF', () => {
       user_age_range: '<13',
     };
 
-    await selfReportToIWF({ ...baseContext }, event, () => {});
+    // @ts-ignore
+    axios.mockImplementationOnce(async () => ({
+      data: {
+        result: 'OK',
+        message: {
+          access_token: 'SECRET TOKEN',
+        },
+      },
+    }));
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(response.getBody()).toMatchObject(
+        expect.objectContaining({
+          reportUrl: `${baseContext.IWF_REPORT_URL}/?t=SECRET TOKEN`,
+        }),
+      );
+    };
+
+    await selfReportToIWF(baseContext, event, callback);
 
     expect(axios).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/selfReportToIWF.test.ts
+++ b/tests/selfReportToIWF.test.ts
@@ -113,18 +113,22 @@ describe('selfReportToIWF', () => {
       },
     }));
 
-    const callback: ServerlessCallback = (err, result) => {
-      expect(result).toBeDefined();
-      const response = result as MockedResponse;
-      expect(response.getStatus()).toBe(200);
-      expect(response.getBody()).toMatchObject(
-        expect.objectContaining({
-          reportUrl: `${baseContext.IWF_REPORT_URL}/?t=SECRET TOKEN`,
-        }),
-      );
-    };
+    const callback = jest.fn();
 
     await selfReportToIWF(baseContext, event, callback);
+
+    expect(callback.mock.results).toHaveLength(1);
+    expect(callback.mock.results[0].type).toBe('return');
+
+    const result = callback.mock.lastCall[1];
+    expect(result).toBeDefined();
+    const response = result as MockedResponse;
+    expect(response.getStatus()).toBe(200);
+    expect(response.getBody()).toMatchObject(
+      expect.objectContaining({
+        reportUrl: `${baseContext.IWF_REPORT_URL}/?t=SECRET TOKEN`,
+      }),
+    );
 
     expect(axios).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Description
Previously, for the self-gen reporting URL flow we were generating: `https://<url>/t?=TOKEN  `
Now it will be: `https://<url>/?t=TOKEN`


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1660)
- [x] New tests added
