### PR TITLE
End post survey task

### DIFF
--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -158,8 +158,10 @@ const endContactOrPostSurvey = async (
     updateTaskPromises.push(updatePostSurveyTask);
   }
 
-  const resolvedPromises = await Promise.all(updateTaskPromises);
-  return resolvedPromises.some((channelCleanupRequired: boolean) => channelCleanupRequired);
+  const resolvedPromises = await Promise.allSettled(updateTaskPromises);
+  const isChannelCleanupRequired = (result: PromiseSettledResult<boolean>) =>
+    result.status === 'fulfilled' && result.value;
+  return resolvedPromises.some(isChannelCleanupRequired);
 };
 
 export const handler = TokenValidator(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2020"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["ES2020"],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2020", "DOM"],                 /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
## Description
This PR fixes the bug in which the post-survey task is not ended when calling `endChat`.

The fix:
- Extracted the code that used to end the contact task to a function
- Applied this function to not only the contact task, but to the post-survey task as well
- Handled `channelCleanupRequired` 

### Related Issues
Fixes https://tech-matters.atlassian.net/browse/CHI-1870

### Verification steps
At webchat, at post-survey stage, the user can hit end chat and the post-survey is ended.
