### PR TITLE
CHI-1972: Fix emojis for line

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,5 +44,6 @@ module.exports = {
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
     "function-paren-newline": "off",
+    "linebreak-style": "off",
   },
 };

--- a/functions/webhooks/line/LineToFlex.ts
+++ b/functions/webhooks/line/LineToFlex.ts
@@ -82,11 +82,6 @@ const fixUnicodeForLine = (text: string): string =>
  */
 const isValidLinePayload = (event: Body, lineChannelSecret: string): boolean => {
   const xLineSignature = event.request.headers['x-line-signature'];
-  console.log(
-    'Line headers',
-    event.request.headers['x-line-signature'],
-    JSON.stringify(event.request.headers),
-  );
   if (!xLineSignature) return false;
 
   // Twilio Serverless adds a 'request' property the payload

--- a/functions/webhooks/line/LineToFlex.ts
+++ b/functions/webhooks/line/LineToFlex.ts
@@ -101,9 +101,11 @@ export const handler = async (
   const resolve = bindResolve(callback)(response);
 
   if (!isValidLinePayload(event, context.LINE_CHANNEL_SECRET)) {
+    console.log('Invalid Line payload', JSON.stringify(event));
     resolve(error403('Forbidden'));
     return;
   }
+  console.log('Valid Line payload', JSON.stringify(event));
 
   try {
     const { destination, events } = event;

--- a/functions/webhooks/line/LineToFlex.ts
+++ b/functions/webhooks/line/LineToFlex.ts
@@ -70,13 +70,11 @@ export type Body = {
 // https://gist.github.com/jirawatee/366d6bef98b137131ab53dfa079bd0a4 - but fixed :facepalm:
 // We get signature mismatches when emojis are present in the payload because the signature on the line side seems to have been generated using escaped versions of emoji unicode characters
 const fixUnicodeForLine = (text: string): string =>
-  text.replace(
-    /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
-    (emojiChars) =>
-      emojiChars
-        .split('')
-        .map((c) => `\\u${c.charCodeAt(0).toString(16).toUpperCase()}`)
-        .join(''),
+  text.replace(/\p{Emoji_Presentation}/gu, (emojiChars) =>
+    emojiChars
+      .split('')
+      .map((c) => `\\u${c.charCodeAt(0).toString(16).toUpperCase()}`)
+      .join(''),
   );
 
 /**

--- a/functions/webhooks/line/LineToFlex.ts
+++ b/functions/webhooks/line/LineToFlex.ts
@@ -92,15 +92,12 @@ const isValidLinePayload = (event: Body, lineChannelSecret: string): boolean => 
   // Twilio Serverless adds a 'request' property the payload
   const { request, ...originalPayload } = event;
   const originalPayloadAsString = JSON.stringify(originalPayload);
-  console.log('originalPayloadAsString', originalPayloadAsString);
 
   const expectedSignature = crypto
     .createHmac('sha256', lineChannelSecret)
     .update(fixUnicodeForLine(originalPayloadAsString))
     .digest('base64');
 
-  console.log('Expected signature', expectedSignature);
-  console.log('Line signature', xLineSignature);
   return crypto.timingSafeEqual(Buffer.from(xLineSignature), Buffer.from(expectedSignature));
 };
 
@@ -113,11 +110,9 @@ export const handler = async (
   const resolve = bindResolve(callback)(response);
 
   if (!isValidLinePayload(event, context.LINE_CHANNEL_SECRET)) {
-    console.log('Invalid Line payload', JSON.stringify(event), JSON.stringify(event.events));
     resolve(error403('Forbidden'));
     return;
   }
-  console.log('Valid Line payload', JSON.stringify(event), JSON.stringify(event.events));
 
   try {
     const { destination, events } = event;

--- a/tests/webhooks/line/LineToFlex.test.ts
+++ b/tests/webhooks/line/LineToFlex.test.ts
@@ -205,6 +205,24 @@ describe('LineToFlex', () => {
       expectedMessage:
         'Message sent in channel line:sender_id.,Message sent in channel line:sender_id.',
     },
+    {
+      conditionDescription: 'sending emoji',
+      event: {
+        ...validEvent(),
+        events: [
+          {
+            ...validEvent().events[0],
+            message: {
+              type: 'text',
+              id: 'message_id',
+              text: 'หนูอยากโตไวๆหนูไม่อยากอยู่กับเขาแล้ว😭',
+            },
+          },
+        ],
+      },
+      expectedStatus: 200,
+      expectedMessage: 'Message sent in channel line:sender_id.',
+    },
   ]).test(
     "Should return error expectedStatus '$expectedMessage' when $conditionDescription",
     async ({

--- a/tests/webhooks/line/LineToFlex.test.ts
+++ b/tests/webhooks/line/LineToFlex.test.ts
@@ -110,13 +110,11 @@ const baseContext = {
 type UnsignedBody = Omit<Body, 'request'>;
 
 const fixUnicodeForLine = (text: string): string =>
-  text.replace(
-    /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
-    (emojiChars) =>
-      emojiChars
-        .split('')
-        .map((c) => `\\u${c.charCodeAt(0).toString(16).toUpperCase()}`)
-        .join(''),
+  text.replace(/\p{Emoji_Presentation}/gu, (emojiChars) =>
+    emojiChars
+      .split('')
+      .map((c) => `\\u${c.charCodeAt(0).toString(16).toUpperCase()}`)
+      .join(''),
   );
 
 const signEvent = (event: UnsignedBody, secret: string): Body => ({


### PR DESCRIPTION
## Description

Fixes CHI-1972, emojis in text should now not have signature mismatches. The issue was reported to LINE here: https://github.com/line/line-bot-sdk-php/issues/269 . The issue seems to be that LINE is unnecessarily escaping emoji unicode characters for JSON (they don't need to be escaped) and using that 'escaped' text to generate the signature, whereas `JSON.stringify` that we use in our signature generating algorithm does not escape these characters, so we get different signatures generated. 

I'm not sure how complete this fix is, because I don't know exactly which characters are being unnecessarily escaped. This fix was specifically focused on emojis, but other Unicode characters should be tested.

I also beefed up the unit tests so now the signature matching algorithm isn't stubbed out, and invalid signature cases are tested

TODO: Remove debug logging

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added


### Related Issues
CHI-1972

### Verification steps

* Start a LINE chat on Aselo Development
* Send standard text back & forth, verify it is received
* Send standard emojis back & forth, verify they are received
* Send 'adjusted' emojis back & forth, like emojis with skin tone adjustments etc.
* Send other Unicode characters
