### PR TITLE
[Bug fix] Cold transfer stuck in "locked" state when user ends the chat during a transfer

### DIFF
--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -57,7 +57,7 @@ const getEndChatMessage = (event: Body): string => {
       const { EndChatMsg } = translation;
       if (EndChatMsg) return EndChatMsg;
     } catch {
-      console.error(`Couldn't retrieve EndChatMsg message translation for ${language}`);
+      console.warn(`Couldn't retrieve EndChatMsg message translation for ${language}`);
     }
   }
   return 'User left the conversation';
@@ -77,48 +77,53 @@ const updateTaskAssignmentStatus = async (
   context: Context<EnvVars>,
   event: Body,
 ) => {
-  const client = context.getTwilioClient();
-  // Fetch the Task to 'cancel' or 'wrapup'
-  const task = await client.taskrouter
-    .workspaces(context.TWILIO_WORKSPACE_SID)
-    .tasks(taskSid)
-    .fetch();
-
-  // Send a Message indicating user left the conversation
-  if (task.assignmentStatus === 'assigned') {
-    const endChatMessage = getEndChatMessage(event);
-    await context
-      .getTwilioClient()
-      .chat.services(context.CHAT_SERVICE_SID)
-      .channels(channelSid)
-      .messages.create({
-        body: endChatMessage,
-        from: 'Bot',
-        xTwilioWebhookEnabled: 'true',
-      });
-  }
-
-  // Update the task assignmentStatus
-  const updateAssignmentStatus = (assignmentStatus: TaskInstance['assignmentStatus']) =>
-    client.taskrouter
+  try {
+    const client = context.getTwilioClient();
+    // Fetch the Task to 'cancel' or 'wrapup'
+    const task = await client.taskrouter
       .workspaces(context.TWILIO_WORKSPACE_SID)
       .tasks(taskSid)
-      .update({ assignmentStatus });
+      .fetch();
 
-  switch (task.assignmentStatus) {
-    case 'reserved':
-    case 'pending': {
-      await updateAssignmentStatus('canceled');
-      return true; // indicate that there's cleanup needed
+    // Send a Message indicating user left the conversation
+    if (task.assignmentStatus === 'assigned') {
+      const endChatMessage = getEndChatMessage(event);
+      await context
+        .getTwilioClient()
+        .chat.services(context.CHAT_SERVICE_SID)
+        .channels(channelSid)
+        .messages.create({
+          body: endChatMessage,
+          from: 'Bot',
+          xTwilioWebhookEnabled: 'true',
+        });
     }
-    case 'assigned': {
-      await updateAssignmentStatus('wrapping');
-      break;
+
+    // Update the task assignmentStatus
+    const updateAssignmentStatus = (assignmentStatus: TaskInstance['assignmentStatus']) =>
+      client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(taskSid)
+        .update({ assignmentStatus });
+
+    switch (task.assignmentStatus) {
+      case 'reserved':
+      case 'pending': {
+        await updateAssignmentStatus('canceled');
+        return 'cleanup'; // indicate that there's cleanup needed
+      }
+      case 'assigned': {
+        await updateAssignmentStatus('wrapping');
+        return 'keep-alive'; // keep the channel alive for post survey
+      }
+      default:
     }
-    default:
+
+    return 'noop'; // no action needed
+  } catch (err) {
+    console.warn(`Unable to end task ${taskSid}:`, err);
+    return 'noop'; // no action needed
   }
-
-  return false; // no cleanup needed
 };
 
 /**
@@ -133,22 +138,18 @@ const endContactOrPostSurvey = async (
 ) => {
   const { tasksSids, surveyTaskSid } = channelAttributes;
 
-  console.log('====================== end chat ======================');
-  console.log('channelAttributes:', channelAttributes);
-  console.log('tasksSids:', tasksSids);
-
   const { channelSid } = event;
-  const updateTaskPromises: Promise<boolean>[] = [];
+  const actionsOnChannel: ReturnType<typeof updateTaskAssignmentStatus>[] = [];
 
   if (tasksSids) {
-    tasksSids.array.forEach((taskSid: string) => {
+    tasksSids.forEach((taskSid: string) => {
       const updateContactTask = updateTaskAssignmentStatus(
         taskSid,
         channelSid as string,
         context,
         event,
       );
-      updateTaskPromises.push(updateContactTask);
+      actionsOnChannel.push(updateContactTask);
     });
   }
 
@@ -159,20 +160,23 @@ const endContactOrPostSurvey = async (
       context,
       event,
     );
-    updateTaskPromises.push(updatePostSurveyTask);
+    actionsOnChannel.push(updatePostSurveyTask);
   }
 
-  const resolvedPromises = await Promise.allSettled(updateTaskPromises);
-  const isChannelCleanupRequired = (result: PromiseSettledResult<boolean>) =>
-    result.status === 'fulfilled' && result.value;
-  return resolvedPromises.some(isChannelCleanupRequired);
+  const resolvedPromises = await Promise.allSettled(actionsOnChannel);
+
+  const isChannelCleanupRequired =
+    !resolvedPromises.some((p) => p.status === 'fulfilled' && p.value === 'keep-alive') &&
+    resolvedPromises.some((p) => p.status === 'fulfilled' && p.value === 'cleanup');
+
+  // Cleanup the channel if all the tasks
+  return isChannelCleanupRequired;
 };
 
 export const handler = TokenValidator(
   async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
     const response = responseWithCors();
     const resolve = bindResolve(callback)(response);
-    console.log(' ------ endChat execution starts -----');
 
     try {
       const client = context.getTwilioClient();
@@ -199,6 +203,17 @@ export const handler = TokenValidator(
         channelAttributes,
         context,
         event,
+      );
+
+      const members = await channel.members().list();
+      await Promise.all(
+        members.map((m) => {
+          if (JSON.parse(m.attributes).member_type !== 'guest') {
+            return m.remove();
+          }
+
+          return Promise.resolve();
+        }),
       );
 
       /** ==================== */

--- a/functions/helpers/addTaskSidToChannelAttributes.private.ts
+++ b/functions/helpers/addTaskSidToChannelAttributes.private.ts
@@ -45,10 +45,15 @@ export const addTaskSidToChannelAttributes = async (context: Context<EnvVars>, e
   // Fetch channel to update with a taskId
   const channel = await client.chat.services(context.CHAT_SERVICE_SID).channels(channelSid).fetch();
 
+  const channelAttributes = JSON.parse(channel.attributes);
+
   const updatedChannel = await channel.update({
     attributes: JSON.stringify({
-      ...JSON.parse(channel.attributes),
-      taskSid: task.sid,
+      ...channelAttributes,
+      tasksSids:
+        channelAttributes.tasksSids && Array.isArray(channelAttributes.tasksSids)
+          ? [...channelAttributes.tasksSids, task.sid]
+          : [task.sid],
     }),
   });
 

--- a/functions/taskrouterListeners/createContactListener.private.ts
+++ b/functions/taskrouterListeners/createContactListener.private.ts
@@ -65,7 +65,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       await addCustomerExternalId(context, event);
 
       if (taskAttributes.channelType === 'web') {
-        // Add tasj sid to tasksSids channel attr so we can end the chat from webchat client (see endChat function)
+        // Add task sid to tasksSids channel attr so we can end the chat from webchat client (see endChat function)
         const addTaskHandlerPath =
           Runtime.getFunctions()['helpers/addTaskSidToChannelAttributes'].path;
         const addTaskSidToChannelAttributes = require(addTaskHandlerPath)

--- a/functions/taskrouterListeners/createContactListener.private.ts
+++ b/functions/taskrouterListeners/createContactListener.private.ts
@@ -65,7 +65,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       await addCustomerExternalId(context, event);
 
       if (taskAttributes.channelType === 'web') {
-        // Add taskSid to channel attr so we can end the chat from webchat client (see endChat function)
+        // Add tasj sid to tasksSids channel attr so we can end the chat from webchat client (see endChat function)
         const addTaskHandlerPath =
           Runtime.getFunctions()['helpers/addTaskSidToChannelAttributes'].path;
         const addTaskSidToChannelAttributes = require(addTaskHandlerPath)

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -41,21 +41,12 @@ export type EnvVars = {
 // ================== //
 // TODO: unify this code with Flex codebase
 
-const hasTransferStarted = (taskAttributes: {
-  transferMeta?: TransferMeta;
-}): taskAttributes is { transferMeta: TransferMeta } =>
-  Boolean(taskAttributes && taskAttributes.transferMeta);
-
-const hasTaskControl = (taskSid: string, taskAttributes: { transferMeta?: TransferMeta }) =>
-  !hasTransferStarted(taskAttributes) || taskAttributes.transferMeta.sidWithTaskControl === taskSid;
-
 const getTaskLanguage = (helplineLanguage: string) => (taskAttributes: { language?: string }) =>
   taskAttributes.language || helplineLanguage;
 // ================== //
 
 const isTriggerPostSurvey = (
   eventType: EventType,
-  taskSid: string,
   taskChannelUniqueName: string,
   taskAttributes: { channelType?: string; transferMeta?: TransferMeta },
 ) => {
@@ -63,8 +54,6 @@ const isTriggerPostSurvey = (
 
   // Post survey is for chat tasks only. This will change when we introduce voice based post surveys
   if (taskChannelUniqueName !== 'chat') return false;
-
-  if (!hasTaskControl(taskSid, taskAttributes)) return false;
 
   // Post survey does not plays well with custom channels (autopilot)
   const handlerPath = Runtime.getFunctions()['helpers/customChannels/customChannelToFlex'].path;
@@ -94,7 +83,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
     const taskAttributes = JSON.parse(taskAttributesString);
 
-    if (isTriggerPostSurvey(eventType, taskSid, taskChannelUniqueName, taskAttributes)) {
+    if (isTriggerPostSurvey(eventType, taskChannelUniqueName, taskAttributes)) {
       console.log('Handling post survey trigger...');
       const client = context.getTwilioClient();
 

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -77,17 +77,12 @@ const isChatTransferToWorkerRejected = (
   eventType: EventType,
   taskChannelUniqueName: string,
   taskAttributes: ChatTransferTaskAttributes,
-) => {
-  console.log('eventType', eventType);
-  console.log('taskAttributes', taskAttributes);
-  return (
-    (eventType === RESERVATION_REJECTED ||
-      eventType === RESERVATION_TIMEOUT ||
-      eventType === TASK_CANCELED) &&
-    isChatTransfer(taskChannelUniqueName, taskAttributes) &&
-    taskAttributes.transferTargetType === 'worker'
-  );
-};
+) =>
+  (eventType === RESERVATION_REJECTED ||
+    eventType === RESERVATION_TIMEOUT ||
+    eventType === TASK_CANCELED) &&
+  isChatTransfer(taskChannelUniqueName, taskAttributes) &&
+  taskAttributes.transferTargetType === 'worker';
 
 const isChatTransferToQueueComplete = (
   eventType: EventType,

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -27,6 +27,7 @@ import {
   RESERVATION_REJECTED,
   RESERVATION_TIMEOUT,
   RESERVATION_WRAPUP,
+  TASK_CANCELED,
   TASK_QUEUE_ENTERED,
 } from '@tech-matters/serverless-helpers/taskrouter';
 
@@ -35,6 +36,7 @@ export const eventTypes: EventType[] = [
   RESERVATION_REJECTED,
   RESERVATION_TIMEOUT,
   RESERVATION_WRAPUP,
+  TASK_CANCELED,
   TASK_QUEUE_ENTERED,
 ];
 
@@ -75,10 +77,17 @@ const isChatTransferToWorkerRejected = (
   eventType: EventType,
   taskChannelUniqueName: string,
   taskAttributes: ChatTransferTaskAttributes,
-) =>
-  (eventType === RESERVATION_REJECTED || eventType === RESERVATION_TIMEOUT) &&
-  isChatTransfer(taskChannelUniqueName, taskAttributes) &&
-  taskAttributes.transferTargetType === 'worker';
+) => {
+  console.log('eventType', eventType);
+  console.log('taskAttributes', taskAttributes);
+  return (
+    (eventType === RESERVATION_REJECTED ||
+      eventType === RESERVATION_TIMEOUT ||
+      eventType === TASK_CANCELED) &&
+    isChatTransfer(taskChannelUniqueName, taskAttributes) &&
+    taskAttributes.transferTargetType === 'worker'
+  );
+};
 
 const isChatTransferToQueueComplete = (
   eventType: EventType,

--- a/tests/taskrouterListeners/postSurveyListener.test.ts
+++ b/tests/taskrouterListeners/postSurveyListener.test.ts
@@ -122,17 +122,6 @@ describe('Post survey init', () => {
       },
       rejectReason: 'is not chat task',
     },
-    {
-      task: {
-        ...successfullyTrasferred,
-        taskChannelUniqueName: 'chat',
-        attributes: {
-          ...successfullyTrasferred.attributes,
-          transferMeta: { sidWithTaskControl: 'a-different-one' },
-        },
-      },
-      rejectReason: 'does not have task controll (incomplete/rejected transfer)',
-    },
     ...Object.values(AseloCustomChannels).map((channelType) => ({
       task: {
         ...nonTrasferred,
@@ -182,8 +171,22 @@ describe('Post survey init', () => {
     },
   );
 
-  each([nonTrasferred, successfullyTrasferred].map((task) => ({ task }))).test(
-    'Task should trigger post survey for candidate taskSid $task.taskSid',
+  each([
+    { task: nonTrasferred },
+    { task: successfullyTrasferred },
+    {
+      task: {
+        ...successfullyTrasferred,
+        taskChannelUniqueName: 'chat',
+        attributes: {
+          ...successfullyTrasferred.attributes,
+          transferMeta: { sidWithTaskControl: 'a-different-one' },
+        },
+      },
+      extraDescription: 'even if does not have task control (in progress/rejected transfer)',
+    },
+  ]).test(
+    'Task should trigger post survey for candidate taskSid $task.taskSid $extraDescription',
     async ({ task }) => {
       const event = {
         ...mock<EventFields>(),

--- a/tests/taskrouterListeners/transfersListener.test.ts
+++ b/tests/taskrouterListeners/transfersListener.test.ts
@@ -20,6 +20,7 @@ import {
   RESERVATION_ACCEPTED,
   RESERVATION_REJECTED,
   RESERVATION_WRAPUP,
+  TASK_CANCELED,
   TASK_QUEUE_ENTERED,
 } from '@tech-matters/serverless-helpers/taskrouter';
 import { Context } from '@twilio-labs/serverless-runtime-types/types';
@@ -237,41 +238,44 @@ describe('Chat transfers', () => {
     expect(tasks['second-task'].update).not.toHaveBeenCalled();
   });
 
-  test('rejected reservation for worker transfer - cancels transfer task & updates the original with transfer task changes', async () => {
-    const event = {
-      ...mock<EventFields>(),
-      EventType: RESERVATION_REJECTED as EventType,
-      TaskChannelUniqueName: 'chat',
-      TaskSid: 'second-task',
-      TaskAttributes: JSON.stringify({ ...defaultAttributes, transferTargetType: 'worker' }),
-    };
+  each([{ eventType: RESERVATION_REJECTED }, { eventType: TASK_CANCELED }]).test(
+    'event $eventType for worker transfer - cancels transfer task & updates the original with transfer task changes',
+    async ({ eventType }) => {
+      const event = {
+        ...mock<EventFields>(),
+        EventType: eventType,
+        TaskChannelUniqueName: 'chat',
+        TaskSid: 'second-task',
+        TaskAttributes: JSON.stringify({ ...defaultAttributes, transferTargetType: 'worker' }),
+      };
 
-    await transfersListener.handleEvent(context, event);
+      await transfersListener.handleEvent(context, event);
 
-    const taskAttributes = JSON.parse(tasks['second-task'].attributes);
+      const taskAttributes = JSON.parse(tasks['second-task'].attributes);
 
-    const attributesWithChannelSid = {
-      ...taskAttributes,
-      channelSid: 'channelSid',
-      transferMeta: {
-        ...taskAttributes.transferMeta,
-        sidWithTaskControl: 'originalReservation-sid',
-      },
-    };
+      const attributesWithChannelSid = {
+        ...taskAttributes,
+        channelSid: 'channelSid',
+        transferMeta: {
+          ...taskAttributes.transferMeta,
+          sidWithTaskControl: 'originalReservation-sid',
+        },
+      };
 
-    const attributesPayload = {
-      attributes: JSON.stringify(attributesWithChannelSid),
-    };
+      const attributesPayload = {
+        attributes: JSON.stringify(attributesWithChannelSid),
+      };
 
-    const canceledPayload = {
-      assignmentStatus: 'canceled',
-      reason: 'task transferred rejected',
-    };
+      const canceledPayload = {
+        assignmentStatus: 'canceled',
+        reason: 'task transferred rejected',
+      };
 
-    console.log((tasks['original-task'].update as jest.Mock).mock.calls);
-    expect(tasks['original-task'].update).toHaveBeenCalledWith(attributesPayload);
-    expect(tasks['second-task'].update).toHaveBeenCalledWith(canceledPayload);
-  });
+      console.log((tasks['original-task'].update as jest.Mock).mock.calls);
+      expect(tasks['original-task'].update).toHaveBeenCalledWith(attributesPayload);
+      expect(tasks['second-task'].update).toHaveBeenCalledWith(canceledPayload);
+    },
+  );
 
   test('rejected reservation for queue transfer - does nothing', async () => {
     const event = {


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/webchat/pull/256.

## Description
This PR fixes is part of the fix to https://tech-matters.atlassian.net/browse/CHI-1965https://tech-matters.atlassian.net/browse/CHI-1965.
This bug occurs because:
- When a new webchat task is created, we add the `taskSid` to the channel attributes, so we can easily find the corresponding task from by having the channel. This is used in the end chat functionality.
- When a transfer is initiated, a second task with the same channel sid is created. This means that the new "transfer task" (not yet accepted), because of the above behavior, was overriding the original `taskSid` in channel attributes.

In this PR, the task sids of all the tasks related to a channel are instead added to a list in the channel attributes. When the user ends the chat, we try to close all the open tasks related to the channel, moving them to the proper state, based on the task state at the time of ending the chat.


### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Verification steps
- Make sure this branch is deployed.
- Start a new local server for webchat using the branch mentioned above.
- Open two Flex sessions.
- Initiate a webchat contact and accept it in one of the Flex sessions.
- Transfer the webchat task from one Flex session to the other, but don't accept it in the second one.
- While the transfer is still in progress, end the chat from the webchat client.
- Confirm that the original task is in wrapup, and that the counselor can interact with the forms. Also the "transfer in progress task" should be removed from the second Flex session.