### PR TITLE
conference/updateParticipant: Added option to set muted

### DIFF
--- a/tests/conference/updateParticipant.test.ts
+++ b/tests/conference/updateParticipant.test.ts
@@ -150,6 +150,32 @@ describe('conference/updateParticipant', () => {
 
   each([
     {
+      when: 'valid update: set "muted" true',
+      body: {
+        conferenceSid: 'conferenceSid',
+        callSid: 'callSid',
+        updateAttribute: 'muted',
+        updateValue: 'true',
+      },
+      expectCallback: () => {
+        expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
+        expect(mockParticipantUpdate).toHaveBeenCalledWith({ muted: true });
+      },
+    },
+    {
+      when: 'valid update: set "muted" false',
+      body: {
+        conferenceSid: 'conferenceSid',
+        callSid: 'callSid',
+        updateAttribute: 'muted',
+        updateValue: 'false',
+      },
+      expectCallback: () => {
+        expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
+        expect(mockParticipantUpdate).toHaveBeenCalledWith({ muted: false });
+      },
+    },
+    {
       when: 'valid update: set "hold" true',
       body: {
         conferenceSid: 'conferenceSid',


### PR DESCRIPTION
## Description
Adds one more valid update to `conference/updateParticipant`, allowing to set the `muted` attribute of conference participants.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added

### Verification steps
- Call from the conference fronted and confirm it sets the value accordingly.