### PR TITLE
Refactored updateParticipant to support multiple updates

### DIFF
--- a/tests/conference/updateParticipant.test.ts
+++ b/tests/conference/updateParticipant.test.ts
@@ -71,8 +71,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: undefined,
         callSid: 'callSid',
-        updateAttribute: 'hold',
-        updateValue: 'false',
+        updates: JSON.stringify({ hold: false }),
       },
       expectedStatus: 400,
     },
@@ -81,40 +80,36 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: undefined,
-        updateAttribute: 'hold',
-        updateValue: 'false',
+        updates: JSON.stringify({ hold: false }),
       },
       expectedStatus: 400,
     },
     {
-      when: 'updateAttribute is missing',
+      when: 'update attribute is an invalid value',
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: undefined,
-        updateValue: 'false',
+        updates: JSON.stringify({ invalid: false }),
       },
       expectedStatus: 400,
     },
     {
-      when: 'updateAttribute is an invalid value',
+      when: 'update value is not bool',
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'invalid',
-        updateValue: 'false',
+        updates: JSON.stringify({ hold: 1 }),
       },
       expectedStatus: 400,
     },
     {
-      when: 'updateValue is missing',
+      when: 'update is missing',
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'hold',
-        updateValue: undefined,
+        updates: undefined,
       },
-      expectedStatus: 400,
+      expectedStatus: 500,
     },
     {
       when: 'conferenceSid does not exists',

--- a/tests/conference/updateParticipant.test.ts
+++ b/tests/conference/updateParticipant.test.ts
@@ -154,7 +154,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updates: { muted: true },
+        updates: JSON.stringify({ muted: true }),
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -166,7 +166,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updates: { muted: false },
+        updates: JSON.stringify({ muted: false }),
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -178,7 +178,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updates: { hold: true },
+        updates: JSON.stringify({ hold: true }),
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -190,7 +190,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updates: { hold: false },
+        updates: JSON.stringify({ hold: false }),
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -202,7 +202,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updates: { endConferenceOnExit: true },
+        updates: JSON.stringify({ endConferenceOnExit: true }),
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -214,7 +214,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updates: { endConferenceOnExit: false },
+        updates: JSON.stringify({ endConferenceOnExit: false }),
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -226,7 +226,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updates: { endConferenceOnExit: false, hold: true },
+        updates: JSON.stringify({ endConferenceOnExit: false, hold: true }),
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);

--- a/tests/conference/updateParticipant.test.ts
+++ b/tests/conference/updateParticipant.test.ts
@@ -154,8 +154,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'muted',
-        updateValue: 'true',
+        updates: { muted: true },
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -167,8 +166,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'muted',
-        updateValue: 'false',
+        updates: { muted: false },
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -180,8 +178,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'hold',
-        updateValue: 'true',
+        updates: { hold: true },
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -193,8 +190,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'hold',
-        updateValue: 'false',
+        updates: { hold: false },
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -206,8 +202,7 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'endConferenceOnExit',
-        updateValue: 'true',
+        updates: { endConferenceOnExit: true },
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
@@ -219,12 +214,26 @@ describe('conference/updateParticipant', () => {
       body: {
         conferenceSid: 'conferenceSid',
         callSid: 'callSid',
-        updateAttribute: 'endConferenceOnExit',
-        updateValue: 'false',
+        updates: { endConferenceOnExit: false },
       },
       expectCallback: () => {
         expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
         expect(mockParticipantUpdate).toHaveBeenCalledWith({ endConferenceOnExit: false });
+      },
+    },
+    {
+      when: 'valid update: set multiple properties',
+      body: {
+        conferenceSid: 'conferenceSid',
+        callSid: 'callSid',
+        updates: { endConferenceOnExit: false, hold: true },
+      },
+      expectCallback: () => {
+        expect(mockParticipantFetch).toHaveBeenCalledTimes(1);
+        expect(mockParticipantUpdate).toHaveBeenCalledWith({
+          endConferenceOnExit: false,
+          hold: true,
+        });
       },
     },
   ]).test('when $when, should return status 200', async ({ body, expectCallback }) => {


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/flex-plugins/pull/1458.

## Description
This PR allows multiple updates on a conference participant in a single API call.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1960)
- [x] New tests added

### Verification steps
Service tests should be enough :)