### PR TITLE
Added conference/statusCallback to keep track of in progress call

### DIFF
--- a/functions/conference/statusCallback.protected.ts
+++ b/functions/conference/statusCallback.protected.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import '@twilio-labs/serverless-runtime-types';
+import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  error500,
+  success,
+  error400,
+} from '@tech-matters/serverless-helpers';
+
+type EnvVars = {
+  SYNC_SERVICE_SID: string;
+};
+
+export type Body = {
+  callStatusSyncDocumentSid?: string;
+  CallStatus: string;
+  request: { cookies: {}; headers: {} };
+};
+
+export const handler = async (
+  context: Context<EnvVars>,
+  event: Body,
+  callback: ServerlessCallback,
+  // eslint-disable-next-line consistent-return
+) => {
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  const { callStatusSyncDocumentSid, CallStatus } = event;
+
+  const client = context.getTwilioClient();
+  try {
+    if (!callStatusSyncDocumentSid) return resolve(error400('callStatusSyncDocumentSid'));
+
+    await client.sync
+      .services(context.SYNC_SERVICE_SID)
+      .documents(callStatusSyncDocumentSid)
+      .update({ data: { CallStatus } });
+
+    resolve(success('Ok'));
+  } catch (err: any) {
+    resolve(error500(err));
+  }
+};

--- a/tests/conference/addParticipant.test.ts
+++ b/tests/conference/addParticipant.test.ts
@@ -66,6 +66,7 @@ describe('conference/addParticipant', () => {
         from: 'from',
         to: 'to',
         label: 'label',
+        callStatusSyncDocumentSid: 'callStatusSyncDocumentSid',
       },
     },
     {
@@ -75,6 +76,7 @@ describe('conference/addParticipant', () => {
         from: undefined,
         to: 'to',
         label: 'label',
+        callStatusSyncDocumentSid: 'callStatusSyncDocumentSid',
       },
     },
     {
@@ -84,6 +86,17 @@ describe('conference/addParticipant', () => {
         from: 'from',
         to: undefined,
         label: 'label',
+        callStatusSyncDocumentSid: 'callStatusSyncDocumentSid',
+      },
+    },
+    {
+      when: 'callStatusSyncDocumentSid is missing',
+      body: {
+        conferenceSid: 'conferenceSid',
+        from: 'from',
+        to: 'to',
+        label: 'label',
+        callStatusSyncDocumentSid: undefined,
       },
     },
   ]).test('when $when, should return status 400', async ({ body }) => {
@@ -102,6 +115,7 @@ describe('conference/addParticipant', () => {
       from: 'from',
       to: 'to',
       label: 'label',
+      callStatusSyncDocumentSid: 'callStatusSyncDocumentSid',
       request: { cookies: {}, headers: {} },
     };
 
@@ -122,6 +136,7 @@ describe('conference/addParticipant', () => {
         from: 'from',
         to: 'to',
         label: 'label',
+        callStatusSyncDocumentSid: 'callStatusSyncDocumentSid',
       },
       expectCallback: () => {
         expect(mockParticipantCreate).toHaveBeenCalledWith({
@@ -130,6 +145,8 @@ describe('conference/addParticipant', () => {
           earlyMedia: true,
           endConferenceOnExit: false,
           label: 'label',
+          statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
+          statusCallback: `https://${baseContext.DOMAIN_NAME}/conference/statusCallback?callStatusSyncDocumentSid=callStatusSyncDocumentSid`,
         });
       },
     },
@@ -139,6 +156,7 @@ describe('conference/addParticipant', () => {
         conferenceSid: 'conferenceSid',
         from: 'from',
         to: 'to',
+        callStatusSyncDocumentSid: 'callStatusSyncDocumentSid',
       },
       expectCallback: () => {
         expect(mockParticipantCreate).toHaveBeenCalledWith({
@@ -147,6 +165,8 @@ describe('conference/addParticipant', () => {
           earlyMedia: true,
           endConferenceOnExit: false,
           label: 'external party',
+          statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
+          statusCallback: `https://${baseContext.DOMAIN_NAME}/conference/statusCallback?callStatusSyncDocumentSid=callStatusSyncDocumentSid`,
         });
       },
     },


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/flex-plugins/pull/1475.

## Description
This PR
- Modifies add participant to include a status callback to track the status of the ongoing external call.
- Adds a conference status callback function that will update a sync document, where the status of the ongoing external call will be tracked to consume from the UI.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

### Verification steps
See PR linked above.