### PR TITLE
Lex trigger pivot

### DIFF
--- a/functions/captureChannelWithBot.protected.ts
+++ b/functions/captureChannelWithBot.protected.ts
@@ -76,10 +76,6 @@ export const handler = async (
       resolve(error400('studioFlowSid'));
       return;
     }
-    if (!language) {
-      resolve(error400('language'));
-      return;
-    }
     if (!type) {
       resolve(error400('type'));
       return;
@@ -123,7 +119,7 @@ export const handler = async (
         fromServiceUser, // Save this in the outer scope so it's persisted for later chatbots
         // All of this can be passed as url params to the webhook instead
         channelCapturedByBot: {
-          language,
+          language: language || 'en',
           type,
           botAlias: 'latest', // assume we always use the latest published version
           studioFlowSid,

--- a/functions/helpers/lexClient.private.ts
+++ b/functions/helpers/lexClient.private.ts
@@ -58,7 +58,8 @@ export const postText = async (
 
   const Lex = new AWS.LexRuntime();
 
-  const botName = `${ENVIRONMENT_CODE}_${HELPLINE_CODE}_${type}_${language.replace('-', '_')}`;
+  // const botName = `${ENVIRONMENT_CODE}_${HELPLINE_CODE}_${type}_${language.replace('-', '_')}`;
+  const botName = 'development_as_survey_en';
   const lexResponse = await Lex.postText({ botName, botAlias, inputText, userId }).promise();
 
   return lexResponse;


### PR DESCRIPTION
## Description
This PR adjust Serverless code to work in accordance with the steps of [this guide](https://techmatters.app.box.com/notes/1249170091888). 

On top of the required adjustments needed to work properly, this PR is hardcoding some values to hit the pre survey bot in Development, until we get this stuff sorted.

To understand why this changes are needed, [here's the explanation I sent in an engineering channel describing the issue and the solution](https://tech-matters.slack.com/archives/CV4QM23UJ/p1688060679176289):

>Basically, the Studio Flows needed to be split in two to integrate with Lex:
A new message will trigger the "channel capture" which means the Lex bot will perform the pre survey (unplugging the chat channel from the Studio Flow). Once survey's finished
A REST trigger will make the chat channel go into the Studio Flow once again. In this second branch we'll want to adjust task attributes, etc, and the last step would be "send to flex", so the task is actually routed to a counselor.
The issue here was reaching the "send to flex" step, as I encountered this error message. I am sorry for not noticing/trying this out earlier. I couldn't find any docs mentioning this limitation, and I was tranquilized being able to send messages back and forth to the channel so I assumed everything should work as expected.
That being said, after a while play around I managed to sort this issue by doing things slightly different than in the initial design:
In Studio Flow, instead than having an "incoming message" trigger and a REST trigger, we have only one "incoming message" trigger. The first widget present in this new Studio Flow is a "split based on" that will evaluate a chat channel attribute flag, called preSurveyComplete. If it is false, the channel will be captured (via the captureChannelWithBot function). If it is true, then we'll route to the usual Studio Flow (deciding task attributes, branching accordingly in different offices, etc). See first picture.
When the pre survey is complete:
The chat channel attributes are modified to include the new flag, preSurveyComplete with value true.
We don't hit the Studio Flow via REST trigger. Instead, we add a new studio type webhook to the chat channel. When a new message arrives to this channel, the studio flow will be triggered as if it was the first time. In companion to this change, we will send the Lex response as the last step, making the last Lex message trigger the Studio Flow (*).
This way we can continue to use the SendToFlex widgets at the very end of our Studio Flow.
A consequence of (*) is that, in the Studio Flow, relying on the trigger.message data may contain incorrect information, as this second trigger is coming from the Bot rather than the original service user. I think, as long as this is known, and we agree on relying on the channel attributes as the source of truth, this won't impact us.
An alternative to the above can be replacing SendToFlex widgets with a Run Function widget that calls a function like /sendToFlex. In this function we should create a new task so that it is routed to Flex. I don't love this idea that much because we know we need to create a new task, but I ignore if the SendToFlex widget does just that, or if there's more hidden magic happening under the hood. Happy to explore this path if the team feel like this is a cleaner solution tho.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
