### PR TITLE
Remove use of post_survey_serverless_handled flag

### DIFF
--- a/functions/endChat.ts
+++ b/functions/endChat.ts
@@ -199,17 +199,12 @@ export const handler = TokenValidator(
         }),
       );
 
-      /** ==================== */
-      /* TODO: Once all accounts are ready to manage triggering post survey on task wrap within taskRouterCallback, the following clean up can be removed */
-      const serviceConfig = await client.flexApi.configuration.get().fetch();
-      const { feature_flags: featureFlags } = serviceConfig.attributes;
-      if (channelCleanupRequired || !featureFlags.post_survey_serverless_handled) {
+      if (channelCleanupRequired) {
         // Deactivate channel and proxy
         const handlerPath = Runtime.getFunctions()['helpers/chatChannelJanitor'].path;
         const chatChannelJanitor = require(handlerPath).chatChannelJanitor as ChatChannelJanitor;
         await chatChannelJanitor(context, { channelSid });
       }
-      /** ==================== */
 
       resolve(success(JSON.stringify({ message: 'End Chat OK!' })));
       return;

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -91,9 +91,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       const serviceConfig = await client.flexApi.configuration.get().fetch();
       const { feature_flags: featureFlags, helplineLanguage } = serviceConfig.attributes;
 
-      /** ==================== */
-      // TODO: Once all accounts are ready to manage triggering post survey on task wrap within taskRouterCallback, the check on post_survey_serverless_handled can be removed
-      if (featureFlags.enable_post_survey && featureFlags.post_survey_serverless_handled) {
+      if (featureFlags.enable_post_survey) {
         const { channelSid } = taskAttributes;
 
         const taskLanguage = getTaskLanguage(helplineLanguage)(taskAttributes);

--- a/tests/taskrouterListeners/postSurveyListener.test.ts
+++ b/tests/taskrouterListeners/postSurveyListener.test.ts
@@ -133,13 +133,13 @@ describe('Post survey init', () => {
     {
       task: nonTrasferred,
       isCandidate: true,
-      featureFlags: { enable_post_survey: true, post_survey_serverless_handled: false },
-      rejectReason: 'is candidate but post_survey_serverless_handled === false',
+      featureFlags: { enable_post_survey: true },
+      rejectReason: 'is candidate with enable_post_survey === true',
     },
     {
       task: nonTrasferred,
       isCandidate: true,
-      featureFlags: { enable_post_survey: false, post_survey_serverless_handled: true },
+      featureFlags: { enable_post_survey: false },
       rejectReason: 'is candidate but enable_post_survey === false',
     },
   ]).test(
@@ -167,7 +167,11 @@ describe('Post survey init', () => {
       } else {
         expect(mockFetchConfig).not.toHaveBeenCalled();
       }
-      expect(postSurveyInitHandlerSpy).not.toHaveBeenCalled();
+      if (featureFlags && featureFlags.enable_post_survey) {
+        expect(postSurveyInitHandlerSpy).toHaveBeenCalled();
+      } else {
+        expect(postSurveyInitHandlerSpy).not.toHaveBeenCalled();
+      }
     },
   );
 
@@ -198,7 +202,7 @@ describe('Post survey init', () => {
 
       mockFetchConfig.mockReturnValue({
         attributes: {
-          feature_flags: { enable_post_survey: true, post_survey_serverless_handled: true },
+          feature_flags: { enable_post_survey: true },
         },
       });
 


### PR DESCRIPTION
## Description
- Removing support for post survey logic being handled in Flex

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #[1969](https://tech-matters.atlassian.net/browse/CHI-1969)

### Verification steps
- Deploying(or ngrok) this branch, and test locally this [PR's](https://github.com/techmatters/flex-plugins/pull/1499) [branch](CHI1969-remove_postsurvey_flexbased) in Flex
- Ensure post survey is triggered when tested
