### PR TITLE
[Bug fix] Duplicated Line contact created when transfer rejected

### DIFF
--- a/.github/workflows/thailand_staging.yml
+++ b/.github/workflows/thailand_staging.yml
@@ -26,3 +26,4 @@ jobs:
       environment_code: 'STG'
       environment: 'staging'
       changelog: 'Deploying individual account'
+      send-slack-message: false

--- a/.github/workflows/thailand_staging.yml
+++ b/.github/workflows/thailand_staging.yml
@@ -26,4 +26,3 @@ jobs:
       environment_code: 'STG'
       environment: 'staging'
       changelog: 'Deploying individual account'
-      send-slack-message: false

--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -89,7 +89,7 @@ const isCleanupCustomChannel = (
   const transferHelers = require(Runtime.getFunctions()['transfer/helpers']
     .path) as TransferHelpers;
 
-  if (transferHelers.hasTaskControl(taskSid, taskAttributes)) {
+  if (!transferHelers.hasTaskControl(taskSid, taskAttributes)) {
     return false;
   }
 

--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -80,7 +80,11 @@ const isCleanupCustomChannel = (
     return false;
   }
 
-  if (isCleanupBotCapture(eventType, taskAttributes)) {
+  const channelCaptureHandlers = require(Runtime.getFunctions()[
+    'channelCapture/channelCaptureHandlers'
+  ].path) as ChannelCaptureHandlers;
+
+  if (channelCaptureHandlers.isChatCaptureControlTask(taskAttributes)) {
     return false;
   }
 

--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -51,13 +51,20 @@ const isCleanupBotCapture = (
   eventType: EventType,
   taskAttributes: { isChatCaptureControl?: boolean },
 ) => {
-  if (eventType === TASK_CANCELED) {
-    const channelCaptureHandlers = require(Runtime.getFunctions()[
-      'channelCapture/channelCaptureHandlers'
-    ].path) as ChannelCaptureHandlers;
-    return channelCaptureHandlers.isChatCaptureControlTask(taskAttributes);
+  if (eventType !== TASK_CANCELED) {
+    return false;
   }
-  return false;
+
+  const channelCaptureHandlers = require(Runtime.getFunctions()[
+    'channelCapture/channelCaptureHandlers'
+  ].path) as ChannelCaptureHandlers;
+
+  console.log(
+    'isCleanupBotCapture: ',
+    channelCaptureHandlers.isChatCaptureControlTask(taskAttributes),
+  );
+
+  return channelCaptureHandlers.isChatCaptureControlTask(taskAttributes);
 };
 
 const isCleanupCustomChannel = (
@@ -68,6 +75,8 @@ const isCleanupCustomChannel = (
     isChatCaptureControl?: boolean;
   } & ChatTransferTaskAttributes,
 ) => {
+  console.log('[isCleanupCustomChannel] Entered isCleanupCustomChannel');
+
   if (
     !(
       eventType === TASK_DELETED ||
@@ -78,16 +87,21 @@ const isCleanupCustomChannel = (
     return false;
   }
 
-  const channelCaptureHandlers = require(Runtime.getFunctions()[
-    'channelCapture/channelCaptureHandlers'
-  ].path) as ChannelCaptureHandlers;
-
-  if (channelCaptureHandlers.isChatCaptureControlTask(taskAttributes)) {
+  if (isCleanupBotCapture(eventType, taskAttributes)) {
+    console.log(
+      '[isCleanupCustomChannel] isCleanupBotCapture: ',
+      isCleanupBotCapture(eventType, taskAttributes),
+    );
     return false;
   }
 
   const transferHelers = require(Runtime.getFunctions()['transfer/helpers']
     .path) as TransferHelpers;
+
+  console.log(
+    '[isCleanupCustomChannel] hasTaskControl',
+    transferHelers.hasTaskControl(taskSid, taskAttributes),
+  );
 
   if (!transferHelers.hasTaskControl(taskSid, taskAttributes)) {
     return false;
@@ -95,6 +109,11 @@ const isCleanupCustomChannel = (
 
   const channelToFlex = require(Runtime.getFunctions()['helpers/customChannels/customChannelToFlex']
     .path) as ChannelToFlex;
+
+  console.log(
+    '[isCleanupCustomChannel] isAseloCustomChannel',
+    channelToFlex.isAseloCustomChannel(taskAttributes.channelType),
+  );
 
   return channelToFlex.isAseloCustomChannel(taskAttributes.channelType);
 };

--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -59,11 +59,6 @@ const isCleanupBotCapture = (
     'channelCapture/channelCaptureHandlers'
   ].path) as ChannelCaptureHandlers;
 
-  console.log(
-    'isCleanupBotCapture: ',
-    channelCaptureHandlers.isChatCaptureControlTask(taskAttributes),
-  );
-
   return channelCaptureHandlers.isChatCaptureControlTask(taskAttributes);
 };
 
@@ -75,8 +70,6 @@ const isCleanupCustomChannel = (
     isChatCaptureControl?: boolean;
   } & ChatTransferTaskAttributes,
 ) => {
-  console.log('[isCleanupCustomChannel] Entered isCleanupCustomChannel');
-
   if (
     !(
       eventType === TASK_DELETED ||
@@ -88,20 +81,11 @@ const isCleanupCustomChannel = (
   }
 
   if (isCleanupBotCapture(eventType, taskAttributes)) {
-    console.log(
-      '[isCleanupCustomChannel] isCleanupBotCapture: ',
-      isCleanupBotCapture(eventType, taskAttributes),
-    );
     return false;
   }
 
   const transferHelers = require(Runtime.getFunctions()['transfer/helpers']
     .path) as TransferHelpers;
-
-  console.log(
-    '[isCleanupCustomChannel] hasTaskControl',
-    transferHelers.hasTaskControl(taskSid, taskAttributes),
-  );
 
   if (!transferHelers.hasTaskControl(taskSid, taskAttributes)) {
     return false;
@@ -109,11 +93,6 @@ const isCleanupCustomChannel = (
 
   const channelToFlex = require(Runtime.getFunctions()['helpers/customChannels/customChannelToFlex']
     .path) as ChannelToFlex;
-
-  console.log(
-    '[isCleanupCustomChannel] isAseloCustomChannel',
-    channelToFlex.isAseloCustomChannel(taskAttributes.channelType),
-  );
 
   return channelToFlex.isAseloCustomChannel(taskAttributes.channelType);
 };

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -25,7 +25,7 @@ import {
   EventType,
   TASK_WRAPUP,
 } from '@tech-matters/serverless-helpers/taskrouter';
-import type { TransferMeta } from './transfersListener.private';
+import type { TransferMeta } from '../transfer/helpers.private';
 import type { PostSurveyInitHandler } from '../postSurveyInit';
 import type { AWSCredentials } from '../channelCapture/lexClient.private';
 import type { ChannelCaptureHandlers } from '../channelCapture/channelCaptureHandlers.private';

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -222,7 +222,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
      * 2) Cancel rejected task
      */
     if (isChatTransferToWorkerRejected(eventType, taskChannelUniqueName, taskAttributes)) {
-      console.log('Handling chat transfer rejected...');
+      console.log('Handling isChatTransferToWorkerRejected...');
 
       const { originalTask: originalTaskSid } = taskAttributes.transferMeta;
       const client = context.getTwilioClient();

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -30,6 +30,7 @@ import {
   TASK_CANCELED,
   TASK_QUEUE_ENTERED,
 } from '@tech-matters/serverless-helpers/taskrouter';
+import type { TransferMeta, ChatTransferTaskAttributes } from '../transfer/helpers.private';
 
 export const eventTypes: EventType[] = [
   RESERVATION_ACCEPTED,
@@ -42,17 +43,6 @@ export const eventTypes: EventType[] = [
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;
-};
-
-export type TransferMeta = {
-  mode: 'COLD' | 'WARM';
-  transferStatus: 'transferring' | 'accepted' | 'rejected';
-  sidWithTaskControl: string;
-};
-
-type ChatTransferTaskAttributes = {
-  transferMeta?: TransferMeta;
-  transferTargetType: 'worker' | 'queue';
 };
 
 const isChatTransfer = (

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -222,7 +222,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
      * 2) Cancel rejected task
      */
     if (isChatTransferToWorkerRejected(eventType, taskChannelUniqueName, taskAttributes)) {
-      console.log('Handling isChatTransferToWorkerRejected...');
+      console.log('Handling chat transfer rejected...');
 
       const { originalTask: originalTaskSid } = taskAttributes.transferMeta;
       const client = context.getTwilioClient();

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -14,8 +14,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-/* eslint-disable global-require */
-/* eslint-disable import/no-dynamic-require */
 import '@twilio-labs/serverless-runtime-types';
 import { Context } from '@twilio-labs/serverless-runtime-types/types';
 

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -252,6 +252,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
         transferMeta: {
           ...originalAttributes.transferMeta,
           sidWithTaskControl: originalAttributes.transferMeta.originalReservation,
+          transferStatus: 'rejected',
         },
       };
 

--- a/functions/transfer/helpers.private.ts
+++ b/functions/transfer/helpers.private.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export type TransferMeta = {
+  mode: 'COLD' | 'WARM';
+  transferStatus: 'transferring' | 'accepted' | 'rejected';
+  sidWithTaskControl: string;
+};
+
+export type ChatTransferTaskAttributes = {
+  transferMeta?: TransferMeta;
+  transferTargetType?: 'worker' | 'queue';
+};
+
+const hasTransferStarted = (taskAttributes: ChatTransferTaskAttributes) =>
+  Boolean(taskAttributes && taskAttributes.transferMeta);
+
+export const hasTaskControl = (taskSid: string, taskAttributes: ChatTransferTaskAttributes) =>
+  !hasTransferStarted(taskAttributes) ||
+  taskAttributes.transferMeta?.sidWithTaskControl === taskSid;
+
+export type TransferHelpers = {
+  hasTaskControl: typeof hasTaskControl;
+};

--- a/tests/taskrouterListeners/janitorListener.test.ts
+++ b/tests/taskrouterListeners/janitorListener.test.ts
@@ -80,6 +80,7 @@ beforeAll(() => {
     'channelCapture/channelCaptureHandlers',
     'functions/channelCapture/channelCaptureHandlers.private',
   );
+  runtime._addFunction('transfer/helpers', 'functions/transfer/helpers.private');
   helpers.setup({}, runtime);
 });
 afterAll(() => {

--- a/tests/taskrouterListeners/janitorListener.test.ts
+++ b/tests/taskrouterListeners/janitorListener.test.ts
@@ -166,4 +166,34 @@ describe('isCleanupCustomChannel', () => {
       expect(mockChannelJanitor).not.toHaveBeenCalled();
     },
   );
+
+  each([
+    ...Object.values(AseloCustomChannels).map((channelType) => ({
+      description: `is rejected transfer task for channelType ${channelType}`,
+      taskAttributes: {
+        ...customChannelTaskAttributes,
+        channelType,
+        transferMeta: { sidWithTaskControl: 'not this task' },
+      },
+    })),
+    ...['web', 'sms', 'whatsapp', 'facebook'].map((channelType) => ({
+      description: `is not custom channel (channelType ${channelType})`,
+      taskAttributes: {
+        ...customChannelTaskAttributes,
+        channelType,
+      },
+    })),
+  ]).test(
+    'canceled task for custom channel $description, should not trigger janitor',
+    async ({ taskAttributes }) => {
+      const event = {
+        ...mock<EventFields>(),
+        EventType: TASK_CANCELED as EventType,
+        TaskAttributes: JSON.stringify(taskAttributes),
+      };
+      await janitorListener.handleEvent(context, event);
+
+      expect(mockChannelJanitor).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/tests/taskrouterListeners/janitorListener.test.ts
+++ b/tests/taskrouterListeners/janitorListener.test.ts
@@ -196,4 +196,25 @@ describe('isCleanupCustomChannel', () => {
       expect(mockChannelJanitor).not.toHaveBeenCalled();
     },
   );
+  each(
+    Object.values(AseloCustomChannels).flatMap((channelType) =>
+      [TASK_DELETED, TASK_SYSTEM_DELETED].map((eventType) => ({
+        description: `is capture control task for channelType ${channelType}`,
+        eventType,
+        taskAttributes: { ...captureControlTaskAttributes, channelType },
+      })),
+    ),
+  ).test(
+    '$eventType for custom channel $description, should not trigger janitor',
+    async ({ taskAttributes, eventType }) => {
+      const event = {
+        ...mock<EventFields>(),
+        EventType: eventType as EventType,
+        TaskAttributes: JSON.stringify(taskAttributes),
+      };
+      await janitorListener.handleEvent(context, event);
+
+      expect(mockChannelJanitor).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/tests/taskrouterListeners/transfersListener.test.ts
+++ b/tests/taskrouterListeners/transfersListener.test.ts
@@ -259,6 +259,7 @@ describe('Chat transfers', () => {
         transferMeta: {
           ...taskAttributes.transferMeta,
           sidWithTaskControl: 'originalReservation-sid',
+          transferStatus: 'rejected',
         },
       };
 


### PR DESCRIPTION
## Description
This PR fixes the bug where, after rejecting a line transfer (or any custom channel really), the next message will result in a duplicated contact. 
The were two causes for this bug:
- [Our implementation of the "chat channel janitor"](https://github.com/techmatters/serverless/blob/master/functions/taskrouterListeners/janitorListener.private.ts) was triggered when the transferred task was rejected (hence canceled), resulting in the chat channel being deactivated. The next message will result in an entire new Studio Flow execution which will ultimately be a new task in Flex.
- Twilio's "Channel Janitor" is enabled for all custom channels in Thai staging, which will do the same as above but on every task being completed/canceled, as this is the default behavior. 
When a task is transferred:
  - A new task will be created to assign to the target counsellor. This task will have `channelSid` attribute set to the original channel in use for the contact. 
  - The original task attributes are modified, among those, the `channelSid` is set to a dummy value. Because of this, when the transfer is accepted, and the original task is canceled, the channel is not deactivated by the Twilio's janitor, as it does not points to the `channelSid` in use.
The logic in this second bullet point was not true for the newly created task in the transfer process, hence when this one was canceled, the Twilio's janitor will have access to the original `channelSid` in use, and deactivates it.
The fix for this is as simple as setting the `channelSid` attribute to a dummy value in the transferred task, when it's rejected.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1959)
- [x] New tests added

### Verification steps
Follow the repro steps in the linked Jira ticket and confirm the issue is not occuring anymore (this code is deployed in Thai staging).