### PR TITLE
Added chatbotCallbackCleanup

### DIFF
--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -152,6 +152,7 @@ const triggerWithUserMessage = async (
   const handlerPath = Runtime.getFunctions()['channelCapture/lexClient'].path;
   const lexClient = require(handlerPath) as LexClient;
 
+  // trigger Lex first, in order to reduce the time between the creating the webhook and sending the message
   const lexResult = await lexClient.postText(context, {
     botName,
     botAlias,

--- a/functions/channelCapture/chatbotCallback.protected.ts
+++ b/functions/channelCapture/chatbotCallback.protected.ts
@@ -97,12 +97,14 @@ export const handler = async (
       });
 
       if (lexResult.status === 'failure') {
+        console.log(lexResult.error.message);
         if (
           lexResult.error.message.includes(
             'Concurrent Client Requests: Encountered resource conflict while saving session data',
           )
         ) {
           console.log('Swallowed Concurrent Client Requests error');
+          resolve(success('Swallowed Concurrent Client Requests error'));
           return;
         }
 

--- a/functions/channelCapture/chatbotCallbackCleanup.protected.ts
+++ b/functions/channelCapture/chatbotCallbackCleanup.protected.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
+import '@twilio-labs/serverless-runtime-types';
+import { omit } from 'lodash';
+import type { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import type { ChannelInstance } from 'twilio/lib/rest/chat/v2/service/channel';
+import {
+  bindResolve,
+  error400,
+  error500,
+  responseWithCors,
+  success,
+} from '@tech-matters/serverless-helpers';
+import type { AWSCredentials, LexClient } from './lexClient.private';
+import type {
+  CapturedChannelAttributes,
+  ChannelCaptureHandlers,
+} from './channelCaptureHandlers.private';
+
+type EnvVars = AWSCredentials & {
+  CHAT_SERVICE_SID: string;
+  ASELO_APP_ACCESS_KEY: string;
+  ASELO_APP_SECRET_KEY: string;
+  AWS_REGION: string;
+  TWILIO_WORKSPACE_SID: string;
+  HRM_STATIC_KEY: string;
+  HELPLINE_CODE: string;
+  ENVIRONMENT: string;
+  SURVEY_WORKFLOW_SID: string;
+};
+
+export type Body = {
+  channelSid: string;
+};
+
+export const chatbotCallbackCleanup = async ({
+  context,
+  channel,
+  channelAttributes,
+  memory: lexMemory,
+  lexClient,
+}: {
+  context: Context<EnvVars>;
+  channel: ChannelInstance;
+  channelAttributes: { [k: string]: any };
+  memory?: { [key: string]: string };
+  lexClient: LexClient;
+}) => {
+  const memory = lexMemory || {};
+
+  const capturedChannelAttributes =
+    channelAttributes.capturedChannelAttributes as CapturedChannelAttributes;
+
+  const releasedChannelAttributes = {
+    ...omit(channelAttributes, ['capturedChannelAttributes']),
+    ...(capturedChannelAttributes.memoryAttribute
+      ? { [capturedChannelAttributes.memoryAttribute]: memory }
+      : { memory }),
+    ...(capturedChannelAttributes.releaseFlag && {
+      [capturedChannelAttributes.releaseFlag]: true,
+    }),
+  };
+
+  const channelCaptureHandlers = require(Runtime.getFunctions()[
+    'channelCapture/channelCaptureHandlers'
+  ].path) as ChannelCaptureHandlers;
+
+  await Promise.all([
+    // Delete Lex session. This is not really needed as the session will expire, but that depends on the config of Lex.
+    lexClient.deleteSession(context, {
+      botName: capturedChannelAttributes.botName,
+      botAlias: capturedChannelAttributes.botAlias,
+      userId: channel.sid,
+    }),
+    // Update channel attributes (remove channelCapturedByBot and add memory)
+    channel.update({
+      attributes: JSON.stringify(releasedChannelAttributes),
+    }),
+    // Remove this webhook from the channel
+    channel.webhooks().get(capturedChannelAttributes.chatbotCallbackWebhookSid).remove(),
+    // Trigger the next step once the channel is released
+    channelCaptureHandlers.handleChannelRelease(
+      context,
+      channel,
+      capturedChannelAttributes,
+      memory,
+    ),
+  ]);
+
+  console.log('Channel unblocked and bot session deleted');
+};
+
+export const handler = async (
+  context: Context<EnvVars>,
+  event: Body,
+  callback: ServerlessCallback,
+) => {
+  console.log('===== chatbotCallbackCleanup handler =====');
+
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  try {
+    const { channelSid } = event;
+    if (!channelSid) {
+      resolve(error400('Body'));
+      return;
+    }
+
+    const client = context.getTwilioClient();
+    const channel = await client.chat
+      .services(context.CHAT_SERVICE_SID)
+      .channels(channelSid)
+      .fetch();
+
+    const channelAttributes = JSON.parse(channel.attributes);
+
+    const lexClient = require(Runtime.getFunctions()['channelCapture/lexClient'].path) as LexClient;
+
+    await chatbotCallbackCleanup({
+      context,
+      channel,
+      channelAttributes,
+      lexClient,
+    });
+
+    resolve(success('All messages sent :)'));
+    return;
+  } catch (err) {
+    if (err instanceof Error) resolve(error500(err));
+    else resolve(error500(new Error(String(err))));
+  }
+};
+
+export type ChatbotCallbackCleanupModule = {
+  chatbotCallbackCleanup: typeof chatbotCallbackCleanup;
+};

--- a/functions/channelCapture/lexClient.private.ts
+++ b/functions/channelCapture/lexClient.private.ts
@@ -40,19 +40,23 @@ export const postText = async (
   },
 ) => {
   const { ASELO_APP_ACCESS_KEY, ASELO_APP_SECRET_KEY, AWS_REGION } = credentials;
-  AWS.config.update({
-    credentials: {
-      accessKeyId: ASELO_APP_ACCESS_KEY,
-      secretAccessKey: ASELO_APP_SECRET_KEY,
-    },
-    region: AWS_REGION,
-  });
+  try {
+    AWS.config.update({
+      credentials: {
+        accessKeyId: ASELO_APP_ACCESS_KEY,
+        secretAccessKey: ASELO_APP_SECRET_KEY,
+      },
+      region: AWS_REGION,
+    });
 
-  const Lex = new AWS.LexRuntime();
+    const Lex = new AWS.LexRuntime();
 
-  const lexResponse = await Lex.postText({ botName, botAlias, inputText, userId }).promise();
+    const lexResponse = await Lex.postText({ botName, botAlias, inputText, userId }).promise();
 
-  return lexResponse;
+    return { status: 'success', lexResponse } as const;
+  } catch (error) {
+    return { status: 'failure', error } as { status: 'failure'; error: Error };
+  }
 };
 
 export const isEndOfDialog = (dialogState: string | undefined) =>

--- a/tests/channelCapture/chatbotCallback.test.ts
+++ b/tests/channelCapture/chatbotCallback.test.ts
@@ -102,6 +102,10 @@ beforeAll(() => {
     'channelCapture/channelCaptureHandlers',
     'functions/channelCapture/channelCaptureHandlers.private',
   );
+  runtime._addFunction(
+    'channelCapture/chatbotCallbackCleanup',
+    'functions/channelCapture/chatbotCallbackCleanup.protected',
+  );
   helpers.setup({}, runtime);
 });
 beforeEach(() => {

--- a/tests/channelCapture/chatbotCallback.test.ts
+++ b/tests/channelCapture/chatbotCallback.test.ts
@@ -19,7 +19,7 @@ import {
   handler as chatbotCallback,
   Body,
 } from '../../functions/channelCapture/chatbotCallback.protected';
-import helpers from '../helpers';
+import helpers, { MockedResponse } from '../helpers';
 import * as lexClient from '../../functions/channelCapture/lexClient.private';
 import * as channelCaptureHandlers from '../../functions/channelCapture/channelCaptureHandlers.private';
 
@@ -161,8 +161,11 @@ describe('chatbotCallback', () => {
     const postTextSpy = jest.spyOn(lexClient, 'postText').mockImplementation(
       async () =>
         ({
-          dialogState: 'ElicitIntent',
-          message: 'Some response from Lex',
+          status: 'success',
+          lexResponse: {
+            dialogState: 'ElicitIntent',
+            message: 'Some response from Lex',
+          },
         } as any),
     );
     const updateChannelSpy = jest.spyOn(mockedChannel, 'update');
@@ -213,9 +216,12 @@ describe('chatbotCallback', () => {
       const postTextSpy = jest.spyOn(lexClient, 'postText').mockImplementation(
         async () =>
           ({
-            dialogState,
-            message: 'Some response from Lex',
-            slots: memory,
+            status: 'success',
+            lexResponse: {
+              dialogState,
+              message: 'Some response from Lex',
+              slots: memory,
+            },
           } as any),
       );
       const deleteSessionSpy = jest
@@ -290,9 +296,12 @@ describe('chatbotCallback', () => {
     jest.spyOn(lexClient, 'postText').mockImplementation(
       async () =>
         ({
-          dialogState: 'Fulfilled',
-          message: 'Some response from Lex',
-          slots: memory,
+          status: 'success',
+          lexResponse: {
+            dialogState: 'Fulfilled',
+            message: 'Some response from Lex',
+            slots: memory,
+          },
         } as any),
     );
     jest.spyOn(lexClient, 'deleteSession').mockImplementation(() => Promise.resolve() as any);
@@ -344,9 +353,12 @@ describe('chatbotCallback', () => {
     jest.spyOn(lexClient, 'postText').mockImplementation(
       async () =>
         ({
-          dialogState: 'Fulfilled',
-          message: 'Some response from Lex',
-          slots: memory,
+          status: 'success',
+          lexResponse: {
+            dialogState: 'Fulfilled',
+            message: 'Some response from Lex',
+            slots: memory,
+          },
         } as any),
     );
     jest.spyOn(lexClient, 'deleteSession').mockImplementation(() => Promise.resolve() as any);
@@ -361,6 +373,52 @@ describe('chatbotCallback', () => {
         ...channelAttributes,
         memoryAttribute: memory,
       }),
+    });
+  });
+
+  test('when Concurrent Client Requests is thrown by Lex client, the callback silently ignores it', async () => {
+    const event: Body = {
+      Body: 'Test body',
+      From: 'serviceUserIdentity',
+      ChannelSid: 'CH123',
+      EventType: 'onMessageSent',
+    };
+
+    const { capturedChannelAttributes, ...channelAttributes } = JSON.parse(
+      mockedChannel.attributes,
+    );
+
+    mockedChannel = {
+      ...defaultChannel,
+      attributes: JSON.stringify({
+        ...channelAttributes,
+        capturedChannelAttributes: {
+          ...capturedChannelAttributes,
+          memoryAttribute: 'memoryAttribute',
+        },
+      }),
+    };
+
+    const updateChannelSpy = jest.spyOn(mockedChannel, 'update');
+
+    jest.spyOn(lexClient, 'postText').mockImplementation(async () => ({
+      status: 'failure',
+      error: new Error(
+        'Concurrent Client Requests: Encountered resource conflict while saving session data',
+      ),
+    }));
+
+    await chatbotCallback(context as any, event, (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+    });
+
+    expect(updateChannelSpy).not.toHaveBeenCalled();
+    expect(mockCreateMessage).not.toHaveBeenCalledWith({
+      body: 'Some response from Lex',
+      from: 'Bot',
+      xTwilioWebhookEnabled: 'true',
     });
   });
 });


### PR DESCRIPTION
## Description
This PR:
- Factors out the logic to cleanup a channel capture, and serves it as a Serverless function to be used from Studio Flow.
- Swallow Concurrent Client Requests error on chatbot callback to avoid unnecessary pages.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2149)
- [x] New tests added

### Verification steps
- Make sure this code is deployed to Development.
- Start a new chat contact. After the bot sends the first message, spam messages and confirm there's no "your function returned an error code" logs in Twilio error logger.
- Confirm that the conversational flow (pre survey -> counselor -> post survey) works as expected (no breaking changes in the cleanup).