### PR TITLE
Mimic DeactivateConversation Orchestration in taskrouter listeners

### DIFF
--- a/functions/helpers/chatChannelJanitor.private.ts
+++ b/functions/helpers/chatChannelJanitor.private.ts
@@ -44,7 +44,7 @@ const deleteProxySession = async (context: Context<EnvVars>, proxySession: strin
 
     if (!ps) {
       // eslint-disable-next-line no-console
-      console.warn(`Tried to remove proxy session ${proxySession} but couldn't find it.`);
+      console.log(`Tried to remove proxy session ${proxySession} but couldn't find it.`);
       return false;
     }
 
@@ -53,7 +53,7 @@ const deleteProxySession = async (context: Context<EnvVars>, proxySession: strin
     return removed;
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn('deleteProxySession error: ', err);
+    console.log('deleteProxySession error: ', err);
     return false;
   }
 };

--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -146,7 +146,15 @@ export const shouldHandle = (event: EventFields) => eventTypes.includes(event.Ev
 
 export const handleEvent = async (context: Context<EnvVars>, event: EventFields) => {
   try {
-    const { EventType: eventType, TaskAttributes: taskAttributesString, TaskSid: taskSid } = event;
+    const {
+      EventType: eventType,
+      TaskAttributes: taskAttributesString,
+      TaskSid: taskSid,
+      TaskChannelUniqueName: taskChannelUniqueName,
+    } = event;
+
+    // The janitor is only be executed for chat based tasks
+    if (taskChannelUniqueName !== 'chat') return;
 
     console.log(`===== Executing JanitorListener for event: ${eventType} =====`);
 

--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -38,6 +38,7 @@ import type { ChatTransferTaskAttributes, TransferHelpers } from '../transfer/he
 export const eventTypes: EventType[] = [
   TASK_CANCELED,
   TASK_WRAPUP,
+  TASK_COMPLETED,
   TASK_DELETED,
   TASK_SYSTEM_DELETED,
 ];

--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -27,6 +27,7 @@ import {
   TASK_WRAPUP,
   TASK_DELETED,
   TASK_SYSTEM_DELETED,
+  TASK_COMPLETED,
 } from '@tech-matters/serverless-helpers/taskrouter';
 
 import type { ChatChannelJanitor } from '../helpers/chatChannelJanitor.private';
@@ -62,6 +63,31 @@ const isCleanupBotCapture = (
   return channelCaptureHandlers.isChatCaptureControlTask(taskAttributes);
 };
 
+const isHandledByOtherListener = (
+  taskSid: string,
+  taskAttributes: {
+    channelType?: string;
+    isChatCaptureControl?: boolean;
+  } & ChatTransferTaskAttributes,
+) => {
+  const channelCaptureHandlers = require(Runtime.getFunctions()[
+    'channelCapture/channelCaptureHandlers'
+  ].path) as ChannelCaptureHandlers;
+
+  if (channelCaptureHandlers.isChatCaptureControlTask(taskAttributes)) {
+    return true;
+  }
+
+  const transferHelers = require(Runtime.getFunctions()['transfer/helpers']
+    .path) as TransferHelpers;
+
+  if (!transferHelers.hasTaskControl(taskSid, taskAttributes)) {
+    return true;
+  }
+
+  return false;
+};
+
 const isCleanupCustomChannel = (
   eventType: EventType,
   taskSid: string,
@@ -70,28 +96,11 @@ const isCleanupCustomChannel = (
     isChatCaptureControl?: boolean;
   } & ChatTransferTaskAttributes,
 ) => {
-  if (
-    !(
-      eventType === TASK_DELETED ||
-      eventType === TASK_SYSTEM_DELETED ||
-      eventType === TASK_CANCELED
-    )
-  ) {
+  if (![TASK_DELETED, TASK_SYSTEM_DELETED, TASK_CANCELED].includes(eventType)) {
     return false;
   }
 
-  const channelCaptureHandlers = require(Runtime.getFunctions()[
-    'channelCapture/channelCaptureHandlers'
-  ].path) as ChannelCaptureHandlers;
-
-  if (channelCaptureHandlers.isChatCaptureControlTask(taskAttributes)) {
-    return false;
-  }
-
-  const transferHelers = require(Runtime.getFunctions()['transfer/helpers']
-    .path) as TransferHelpers;
-
-  if (!transferHelers.hasTaskControl(taskSid, taskAttributes)) {
+  if (isHandledByOtherListener(taskSid, taskAttributes)) {
     return false;
   }
 
@@ -99,6 +108,29 @@ const isCleanupCustomChannel = (
     .path) as ChannelToFlex;
 
   return channelToFlex.isAseloCustomChannel(taskAttributes.channelType);
+};
+
+const isDeactivateConversationOrchestration = (
+  eventType: EventType,
+  taskSid: string,
+  taskAttributes: {
+    channelType?: string;
+    isChatCaptureControl?: boolean;
+  } & ChatTransferTaskAttributes,
+) => {
+  if (
+    ![TASK_WRAPUP, TASK_COMPLETED, TASK_DELETED, TASK_SYSTEM_DELETED, TASK_CANCELED].includes(
+      eventType,
+    )
+  ) {
+    return false;
+  }
+
+  if (isHandledByOtherListener(taskSid, taskAttributes)) {
+    return false;
+  }
+
+  return true;
 };
 
 const wait = (ms: number): Promise<void> =>
@@ -143,6 +175,25 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       return;
     }
 
+    if (isDeactivateConversationOrchestration(eventType, taskSid, taskAttributes)) {
+      // This task has reached a point where the channel should be deactivated, unless post survey is enabled
+      const client = context.getTwilioClient();
+      const serviceConfig = await client.flexApi.configuration.get().fetch();
+      const { feature_flags: featureFlags } = serviceConfig.attributes;
+
+      // TODO: remove featureFlags.backend_handled_chat_janitor condition once all accounts are updated, since we want this code to be executed in all Flex instances once CHI-2202 is implemented and in place
+      if (!featureFlags.enable_post_survey && featureFlags.backend_handled_chat_janitor) {
+        console.log('Handling DeactivateConversationOrchestration...');
+
+        const chatChannelJanitor = require(Runtime.getFunctions()['helpers/chatChannelJanitor']
+          .path).chatChannelJanitor as ChatChannelJanitor;
+        await chatChannelJanitor(context, { channelSid: taskAttributes.channelSid });
+
+        console.log('Finished DeactivateConversationOrchestration.');
+        return;
+      }
+    }
+
     console.log('===== JanitorListener finished successfully =====');
   } catch (err) {
     console.log('===== JanitorListener has failed =====');
@@ -155,9 +206,9 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
  * The taskrouter callback expects that all taskrouter listeners return
  * a default object of type TaskrouterListener.
  */
-const transfersListener: TaskrouterListener = {
+const janitorListener: TaskrouterListener = {
   shouldHandle,
   handleEvent,
 };
 
-export default transfersListener;
+export default janitorListener;

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -102,8 +102,6 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       const serviceConfig = await client.flexApi.configuration.get().fetch();
       const { feature_flags: featureFlags, helplineLanguage } = serviceConfig.attributes;
 
-      /** ==================== */
-      // TODO: Once all accounts are ready to manage triggering post survey on task wrap within taskRouterCallback, the check on post_survey_serverless_handled can be removed
       if (featureFlags.enable_post_survey) {
         const channelToFlex = require(Runtime.getFunctions()[
           'helpers/customChannels/customChannelToFlex'


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/flex-plugins/pull/1627

## Description
This PR adds more conditions under which the chat channel janitor should be executed. In particular, we want it to execute for all chat channels for those accounts where post survey is disabled, upon any taskrouter event that moves a task to a "final state". A temporary flag `backend_handled_chat_janitor` is introduced in order to make the synchronization between above Flex branch and this code compatible without making a hard dependency in the deploys. Once all accounts are updated we can get rid of this flag.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2202)
- [x] New tests added

### Verification steps
- Make sure the feature flags are set to `enable_post_survey`: `false` and `backend_handled_chat_janitor`: `true`.
- Make `master` Flex is deployed to Aselo Development.
- Make `master` is deployed to Aselo Development.
- Start a new webchat contact and accept in Flex.
- Click "End chat" in webchat.
- Try to submit save the contact into HRM, it should fail with a "Cant deactivate chat channel" error message.
- Make sure the above linked Flex PR is deployed to Aselo Development.
- Make sure this PR is deployed to Aselo Development.
- Start a new webchat contact and accept in Flex.
- Click "End chat" in webchat.
- Try to submit save the contact into HRM, it should succeed.