### PR TITLE
[Bug fix] Make channel capture cleanup function compatible with channel not captured

### DIFF
--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -160,10 +160,6 @@ const triggerWithUserMessage = async (
     inputText,
   });
 
-  if (lexResult.status === 'failure') {
-    throw lexResult.error;
-  }
-
   const chatbotCallbackWebhook = await channel.webhooks().create({
     type: 'webhook',
     configuration: {
@@ -185,6 +181,11 @@ const triggerWithUserMessage = async (
     memoryAttribute,
     chatbotCallbackWebhookSid: chatbotCallbackWebhook.sid,
   });
+
+  // Bubble exception after the channel is updated because capture attributes are needed for the cleanup
+  if (lexResult.status === 'failure') {
+    throw lexResult.error;
+  }
 
   const { lexResponse } = lexResult;
 

--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -507,7 +507,7 @@ const handlePostSurveyComplete = async (
         : !postSurveyConfigJson
         ? `No postSurveyConfigJson found for definitionVersion ${definitionVersion}.`
         : `postSurveyConfigJson for definitionVersion ${definitionVersion} is not a Twilio asset as expected`; // This should removed when if we move definition versions to an external source.
-    console.error(`Error accessing to the post survey form definitions: ${errorMEssage}`);
+    console.info(`Error accessing to the post survey form definitions: ${errorMEssage}`);
   }
 };
 

--- a/functions/channelCapture/chatbotCallbackCleanup.protected.ts
+++ b/functions/channelCapture/chatbotCallbackCleanup.protected.ts
@@ -69,13 +69,12 @@ export const chatbotCallbackCleanup = async ({
 
   const releasedChannelAttributes = {
     ...omit(channelAttributes, ['capturedChannelAttributes']),
-    ...(capturedChannelAttributes && capturedChannelAttributes.memoryAttribute
+    ...(capturedChannelAttributes.memoryAttribute
       ? { [capturedChannelAttributes.memoryAttribute]: memory }
       : { memory }),
-    ...(capturedChannelAttributes &&
-      capturedChannelAttributes.releaseFlag && {
-        [capturedChannelAttributes.releaseFlag]: true,
-      }),
+    ...(capturedChannelAttributes.releaseFlag && {
+      [capturedChannelAttributes.releaseFlag]: true,
+    }),
   };
 
   const channelCaptureHandlers = require(Runtime.getFunctions()[
@@ -84,19 +83,17 @@ export const chatbotCallbackCleanup = async ({
 
   await Promise.all([
     // Delete Lex session. This is not really needed as the session will expire, but that depends on the config of Lex.
-    capturedChannelAttributes &&
-      lexClient.deleteSession(context, {
-        botName: capturedChannelAttributes.botName,
-        botAlias: capturedChannelAttributes.botAlias,
-        userId: channel.sid,
-      }),
+    lexClient.deleteSession(context, {
+      botName: capturedChannelAttributes.botName,
+      botAlias: capturedChannelAttributes.botAlias,
+      userId: channel.sid,
+    }),
     // Update channel attributes (remove channelCapturedByBot and add memory)
     channel.update({
       attributes: JSON.stringify(releasedChannelAttributes),
     }),
     // Remove this webhook from the channel
-    capturedChannelAttributes &&
-      channel.webhooks().get(capturedChannelAttributes.chatbotCallbackWebhookSid).remove(),
+    channel.webhooks().get(capturedChannelAttributes.chatbotCallbackWebhookSid).remove(),
     // Trigger the next step once the channel is released
     channelCaptureHandlers.handleChannelRelease(
       context,

--- a/functions/channelCapture/chatbotCallbackCleanup.protected.ts
+++ b/functions/channelCapture/chatbotCallbackCleanup.protected.ts
@@ -69,12 +69,13 @@ export const chatbotCallbackCleanup = async ({
 
   const releasedChannelAttributes = {
     ...omit(channelAttributes, ['capturedChannelAttributes']),
-    ...(capturedChannelAttributes.memoryAttribute
+    ...(capturedChannelAttributes && capturedChannelAttributes.memoryAttribute
       ? { [capturedChannelAttributes.memoryAttribute]: memory }
       : { memory }),
-    ...(capturedChannelAttributes.releaseFlag && {
-      [capturedChannelAttributes.releaseFlag]: true,
-    }),
+    ...(capturedChannelAttributes &&
+      capturedChannelAttributes.releaseFlag && {
+        [capturedChannelAttributes.releaseFlag]: true,
+      }),
   };
 
   const channelCaptureHandlers = require(Runtime.getFunctions()[
@@ -83,17 +84,19 @@ export const chatbotCallbackCleanup = async ({
 
   await Promise.all([
     // Delete Lex session. This is not really needed as the session will expire, but that depends on the config of Lex.
-    lexClient.deleteSession(context, {
-      botName: capturedChannelAttributes.botName,
-      botAlias: capturedChannelAttributes.botAlias,
-      userId: channel.sid,
-    }),
+    capturedChannelAttributes &&
+      lexClient.deleteSession(context, {
+        botName: capturedChannelAttributes.botName,
+        botAlias: capturedChannelAttributes.botAlias,
+        userId: channel.sid,
+      }),
     // Update channel attributes (remove channelCapturedByBot and add memory)
     channel.update({
       attributes: JSON.stringify(releasedChannelAttributes),
     }),
     // Remove this webhook from the channel
-    channel.webhooks().get(capturedChannelAttributes.chatbotCallbackWebhookSid).remove(),
+    capturedChannelAttributes &&
+      channel.webhooks().get(capturedChannelAttributes.chatbotCallbackWebhookSid).remove(),
     // Trigger the next step once the channel is released
     channelCaptureHandlers.handleChannelRelease(
       context,

--- a/functions/helpers/addCustomerExternalId.private.ts
+++ b/functions/helpers/addCustomerExternalId.private.ts
@@ -41,7 +41,7 @@ const logAndReturnError = (
   errorInstance: unknown,
 ) => {
   const errorMessage = `Error at addCustomerExternalId: task with sid ${taskSid} does not exists in workspace ${workspaceSid} when trying to ${step} it.`;
-  console.error(errorMessage, errorInstance);
+  console.info(errorMessage, errorInstance);
   return { message: errorMessage };
 };
 

--- a/functions/postSurveyComplete.protected.ts
+++ b/functions/postSurveyComplete.protected.ts
@@ -123,7 +123,7 @@ const getPostSurveyCompleteMessage = async (
 
     if (translation.postSurveyCompleteMessage) return translation.postSurveyCompleteMessage;
   } catch {
-    console.error(
+    console.info(
       `Couldn't retrieve postSurveyCompleteMessage translation for ${taskLanguage}, neither default (en-US).`,
     );
   }
@@ -196,7 +196,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
               : !postSurveyConfigJson
               ? `No postSurveyConfigJson found for definitionVersion ${definitionVersion}.`
               : `postSurveyConfigJson for definitionVersion ${definitionVersion} is not a Twilio asset as expected`; // This should removed when if we move definition versions to an external source.
-          console.error(`Error accessing to the post survey form definitions: ${errorMEssage}`);
+          console.info(`Error accessing to the post survey form definitions: ${errorMEssage}`);
         }
 
         // As survey tasks will never be assigned to a worker, they'll be kept in pending state. A pending can't transition to completed state, so we cancel them here to raise a task.canceled taskrouter event.

--- a/functions/postSurveyInit.ts
+++ b/functions/postSurveyInit.ts
@@ -123,7 +123,7 @@ const getTriggerMessage = async (
 
       if (translation.triggerMessage) return translation.triggerMessage;
     } catch {
-      console.error(`Couldn't retrieve triggerMessage translation for ${taskLanguage}`);
+      console.info(`Couldn't retrieve triggerMessage translation for ${taskLanguage}`);
     }
   }
 

--- a/tests/helpers/addCustomerExternalId.test.ts
+++ b/tests/helpers/addCustomerExternalId.test.ts
@@ -71,7 +71,7 @@ const baseContext = {
 
 const liveAttributes = { some: 'some', customers: { other: 1 } };
 
-const logSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+const logSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
 
 beforeAll(() => {
   helpers.setup({});


### PR DESCRIPTION
## Description
This PR fixes some issues found in `/channelCapture/chatbotCallbackCleanup` function, caused because of the assumption that the channel is successfully captured when it may not.

The changes included in this PR are:
- `/channelCapture/channelCaptureHandlers` continues to bubble the error (if any) from the Lex response, but only after the channel attributes have been updated, since those attributes are required in the cleanup function.
- Lex client's `deleteSession` function is wrapped in a Result to avoid throwing, as that can cause the cleanup to error when the Lex session does not exists (due to a channel capture error). With this change we prevent the promise to reject. If we ever need to "consume the error", that can be done by just evaluating the returned result, but right now we don't care about it.
- Remove remaining `console.error`s to avoid paging people :)

### Verification steps
If @janorivera approves this PR, it means he already tested the behavior :P