### PR TITLE
Chi 2213 migrate e2e account autopilot lex

### DIFF
--- a/.github/actions/custom-actions/action.yml
+++ b/.github/actions/custom-actions/action.yml
@@ -82,3 +82,6 @@ runs:
     - name: Zambia Production release custom action
       if: inputs.helpline-name == format('ZM_PROD')
       uses: ./.github/actions/custom-actions/zambia_production_custom
+    - name: E2E Development release custom action
+      if: inputs.helpline-name == format('E2E_DEV')
+      uses: ./.github/actions/custom-actions/e2e_development_custom

--- a/.github/actions/custom-actions/e2e_development_custom/action.yml
+++ b/.github/actions/custom-actions/e2e_development_custom/action.yml
@@ -30,5 +30,9 @@ runs:
           env_variable_name: "HELPLINE_CODE"
       # Append environment variables
       - name: Add HELPLINE_CODE
-        run: echo "HELPLINE_CODE=${{ env.HELPLINE_CODE }}" >> .env
+        # run: echo "HELPLINE_CODE=${{ env.HELPLINE_CODE }}" >> .env
+
+        run: |
+          echo "Setting helpline-code for e2e"
+          echo "HELPLINE_CODE=$HELPLINE_CODE" >> .env
         shell: bash

--- a/.github/actions/custom-actions/e2e_development_custom/action.yml
+++ b/.github/actions/custom-actions/e2e_development_custom/action.yml
@@ -1,0 +1,34 @@
+# Copyright (C) 2021-2023 Technology Matters
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/.
+
+name: 'E2E Development release custom action'
+description: 'Sets up environment variables related to non-standard additional features in use in E2E Development environment'
+inputs:
+  account-sid:
+    description: 'The Twilio Account SID for this account'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # Since we can't provision a lex chat bot with e2e as the helpline code
+      # we will have to change the helpline code for the E2E account to "ee" on serverless
+      - name: Set Helpline Code for E2E Account
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: "DEV_TWILIO_E2E_HELPLINE_CODE"
+          env_variable_name: "HELPLINE_CODE"
+      # Append environment variables
+      - name: Add HELPLINE_CODE
+        run: echo "HELPLINE_CODE=${{ env.HELPLINE_CODE }}" >> .env
+        shell: bash

--- a/.github/actions/custom-actions/e2e_development_custom/action.yml
+++ b/.github/actions/custom-actions/e2e_development_custom/action.yml
@@ -30,9 +30,9 @@ runs:
           env_variable_name: "HELPLINE_CODE"
       # Append environment variables
       - name: Add HELPLINE_CODE
-        # run: echo "HELPLINE_CODE=${{ env.HELPLINE_CODE }}" >> .env
+        run: echo "HELPLINE_CODE=${{ env.HELPLINE_CODE }}" >> .env
 
-        run: |
-          echo "Setting helpline-code for e2e"
-          echo "HELPLINE_CODE=$HELPLINE_CODE" >> .env
+        # run: |
+        #   echo "Setting helpline-code for e2e"
+        #   echo "HELPLINE_CODE=$HELPLINE_CODE" >> .env
         shell: bash

--- a/.github/actions/custom-actions/e2e_development_custom/action.yml
+++ b/.github/actions/custom-actions/e2e_development_custom/action.yml
@@ -31,8 +31,4 @@ runs:
       # Append environment variables
       - name: Add HELPLINE_CODE
         run: echo "HELPLINE_CODE=${{ env.HELPLINE_CODE }}" >> .env
-
-        # run: |
-        #   echo "Setting helpline-code for e2e"
-        #   echo "HELPLINE_CODE=$HELPLINE_CODE" >> .env
         shell: bash

--- a/.github/workflows/deploy-multiple-accounts.yml
+++ b/.github/workflows/deploy-multiple-accounts.yml
@@ -124,27 +124,6 @@ jobs:
           ssm_parameter: ${{env.TWILIO_SSM_PREFIX}}_POST_SURVEY_BOT_CHAT_URL
           env_variable_name: POST_SURVEY_BOT_CHAT_URL
 
-      # Since we can't provision a lex chat bot with e2e as the helpline code
-      # we will have to change the helpline code for the E2E account to "ee" on serverless
-      - name: Set Helpline Code for E2E Account
-        if: matrix.helpline_code == 'E2E'
-        uses: marvinpinto/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: ${{env.TWILIO_SSM_PREFIX}}_HELPLINE_CODE
-          env_variable_name: HELPLINE_CODE
-        
-      - name: Check and Set Helpline Code
-        if: matrix.helpline_code == 'E2E'
-        run: |
-          echo "Setting helpline-code to $HELPLINE_CODE"
-          echo "HELPLINE_CODE=$HELPLINE_CODE" >> $GITHUB_ENV
-          
-      - name: Set Helpline Code (else part)
-        if: matrix.helpline_code != 'E2E'
-        run: |
-          echo "Setting helpline-code to matrix.helpline_code"
-          echo "HELPLINE_CODE=${{ matrix.helpline_code }}" >> $GITHUB_ENV
-
       - name: Set AWS credentials for Aselo user
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
@@ -193,7 +172,7 @@ jobs:
           aselo-app-secret-key: $ASELO_APP_SECRET_KEY
           aws-region: $HELPLINE_AWS_REGION
           s3-bucket: $S3_BUCKET
-          helpline-code: "${{env.HELPLINE_CODE}}"
+          helpline-code: ${{matrix.helpline_code}}
           environment-code: ${{matrix.environment_code}}
           environment: ${{env.FULL_ENVIRONMENT_NAME}}
           # Set 'false' if the target environment is production OR the force_enable_operating_hours override option is checked - otherwise 'true'


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

Refactor how to set helpline code

Since we can't provision a lex chatbot with e2e as the helpline code we will have to change the helpline code for the E2E account to "ee" on serverless

This PR content is the feedback implementation from @stephenhand where I added the _HELPLINE_CODE lookup specifically in a custom action for the E2E account.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
