### PR TITLE
[POC] Blocked profiles: add getProfileFlagsForIdentifier

### DIFF
--- a/functions/getProfileFlagsForIdentifier.protected.ts
+++ b/functions/getProfileFlagsForIdentifier.protected.ts
@@ -104,8 +104,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
     const serviceConfig = await client.flexApi.configuration.get().fetch();
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { hrm_base_url, hrm_api_version } = serviceConfig.attributes;
-    // const hrmBaseUrl = `${hrm_base_url}/${hrm_api_version}/accounts/${serviceConfig.accountSid}`;
-    const hrmBaseUrl = `http://localhost:8080/${hrm_api_version}/accounts/${serviceConfig.accountSid}`;
+    const hrmBaseUrl = `${hrm_base_url}/${hrm_api_version}/accounts/${serviceConfig.accountSid}`;
     const { trigger } = event;
 
     const identifier = getIdentifier(trigger);

--- a/functions/getProfileFlagsForIdentifier.ts
+++ b/functions/getProfileFlagsForIdentifier.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/* eslint-disable no-console */
+/* eslint-disable import/no-dynamic-require */
+/* eslint-disable global-require */
+import {
+  bindResolve,
+  error500,
+  responseWithCors,
+  send,
+  success,
+} from '@tech-matters/serverless-helpers';
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+// We use axios instead of node-fetch in this repo because the later one raises a run time error when trying to import it. The error is related to how JS modules are loaded.
+import axios from 'axios';
+
+type ChatTrigger = {
+  message: {
+    ChannelAttributes: {
+      pre_engagement_data?: {
+        contactIdentifier: string;
+      };
+      from: string;
+      channel_type: string;
+    };
+  };
+};
+const isChatTrigger = (obj: any): obj is VoiceTrigger =>
+  obj && obj.message && typeof obj.message === 'object';
+
+type VoiceTrigger = {
+  call: {
+    From: string;
+    Caller: string;
+  };
+};
+const isVoiceTrigger = (obj: any): obj is VoiceTrigger =>
+  obj && obj.call && typeof obj.call === 'object';
+
+export type Event = {
+  trigger: ChatTrigger | VoiceTrigger;
+  request: { cookies: {}; headers: {} };
+};
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+  HRM_STATIC_KEY: string;
+};
+
+const getContactValueFromWebchat = (trigger: ChatTrigger) => {
+  const preEngagementData = trigger.message.ChannelAttributes.pre_engagement_data;
+  if (!preEngagementData) return '';
+  return preEngagementData.contactIdentifier;
+};
+
+export const getIdentifier = (trigger: Event['trigger']) => {
+  if (isVoiceTrigger(trigger)) {
+    return trigger.call.From;
+  }
+
+  if (isChatTrigger(trigger)) {
+    if (trigger.message.ChannelAttributes.channel_type === 'facebook') {
+      return trigger.message.ChannelAttributes.from.replace('messenger:', '');
+    }
+    if (trigger.message.ChannelAttributes.channel_type === 'whatsapp') {
+      return trigger.message.ChannelAttributes.from.replace('whatsapp:', '');
+    }
+    if (trigger.message.ChannelAttributes.channel_type === 'web') {
+      return getContactValueFromWebchat(trigger);
+    }
+  }
+
+  throw new Error('Trigger is none VoiceTrigger nor ChatTrigger');
+};
+
+export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
+  context: Context<EnvVars>,
+  event: Event,
+  callback: ServerlessCallback,
+) => {
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  try {
+    const client = context.getTwilioClient();
+    const serviceConfig = await client.flexApi.configuration.get().fetch();
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { hrm_base_url, hrm_api_version } = serviceConfig.attributes;
+    // const hrmBaseUrl = `${hrm_base_url}/${hrm_api_version}/accounts/${serviceConfig.accountSid}`;
+    const hrmBaseUrl = `http://localhost:8080/${hrm_api_version}/accounts/${serviceConfig.accountSid}`;
+    const { trigger } = event;
+
+    const identifier = getIdentifier(trigger);
+    const res = await axios({
+      url: `${hrmBaseUrl}/profiles/identifier/${identifier}/flags`,
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${context.HRM_STATIC_KEY}`,
+      },
+      validateStatus: () => true, // don't throw on "failure" status codes
+    });
+
+    if (res.status !== 200) {
+      resolve(send(res.status)(res.data));
+      return;
+    }
+
+    console.log(res.data);
+    resolve(success({ flags: res.data.map((flag: { name: string }) => flag.name) })); // return a list with the flags' names only
+  } catch (err: any) {
+    resolve(error500(err));
+  }
+};


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/hrm/pull/495.

## Description
This PR is part of the PoC for rejecting contacts for profiles that have been marked as "blocked".

This PR adds a new protected function `getProfileFlagsForIdentifier`. 
The function
- Expects the entire `trigger` object (a.k.a. what triggered a Studio Flow execution). Depending on the type of trigger, the function will pull the `identifier` (and transform it as we do when we store them in our DB), and then will retrieve from HRM all the profile flags associated for this identifier.
- Returns the list of the names associated to the given identifier (if there are multiple profiles, will return all the flags associated to all the profiles).

The idea of this function is to be used from Studio Flows, so the flows can then use the list of flags to decide how to properly route the contact (reject it if `blocked`, prioritize if there's some other arbitrary flag, etc).

In order for this to work, the Studio Flows need to be updated like:
- Add a new "function call" widget that calls `getProfileFlagsForIdentifier`, sending the entire trigger object to it like `{ "trigger": {{trigger | to_json}} }`. Make this widget to be the very  first one in the Studio Flow.
- Add a new "split based on variable" widget that tests `widgets.getProfileFlagsForIdentifier.parsed.flags`. Add a new condition to check if it `CONTAINS blocked`. Wire the above widget to this one in case of success. Route to the usual Studio Flow if `no condition matches`.
- Add a new "function call" widget that calls `/sendMessageAndRunJanitor` function to send a "you are blocked message". Route the condition `CONTAINS blocked` of the above widget to this one.

![Screenshot from 2023-11-08 19-36-51](https://github.com/techmatters/serverless/assets/15805319/f62422b2-e5cd-49cf-921e-ebb35d0baaf8)

If everything is correctly set, chats should work as usual, except for those that are blocked, which will display a message like the following, and immediately end the chat.

![Screenshot from 2023-11-08 19-15-36](https://github.com/techmatters/serverless/assets/15805319/d7e17677-3fc4-4cb9-9146-24d5479869c6)


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2327)
- [ ] New tests added

### Verification steps
- Start local HRM server using the branch linked above (`npm run build & npm run start:light`).
- Start local Flex using some the latest branch containing client  profiles (`npm run dev:local`).
- Save one contact (so your own identifier gets to be created in the DB).
- Start local serverless branch using commit [91d84cc](https://github.com/techmatters/serverless/pull/536/commits/91d84cc7a2e35746db48b1ad2a46bc396edbd3a8) of this branch (it contains a less productionized but friendlier for testing version of the function).
- Make sure you have `HRM_STATIC_KEY=<the static key for Aselo dev>` set in your env vars for serverless repo. If not, look for it either in AWS parameter store or in the deployed serverless instance in Twilio Console.
- Start serverless local server (`npm run start:local`).
- Expose the local serverless via ngrok (`ngrok http 3030`).
- Via Twilio Console (Aselo Development account), edit the Messaging Studio Flow so it  looks like the 1st image from above.
- Edit the `getProfileFlagsForIdentifier` widget of the Flow, under the "request url" section, using your ngrok exposed url so the call to the function is routed to your local instance.
- Publish the Studio Flow.
- Start a new chat and confirm it works as usual. Confirm that the Studio Flow called your local serverless instance and that it redirected the call to HRM.
- Create a new association between your identifier and the `blocked` flag. This can be done using a DB admin like:
  - Find the ID of the profile that got created for your identifier (`SELECT * FROM "Profiles"` and find the right one, probably the newest one). Also get the account sid here.
  - Find the ID of the `blocked` profile flag (`SELECT * FROM "ProfileFlags"`).
  - Insert a new record in the association table between the flag and your profile
    ```
        INSERT INTO "ProfilesToProfileFlags" ("profileId", "profileFlagId", "accountSid", "createdAt", "updatedAt")
        VALUES (<your profileId>, <blocked profileFlagId>, <account  sid>, current_timestamp, current_timestamp)
    ```
- Attempt a new contact using the same channel you used before (and the one that corresponds to the now blocked identifier).
- Confirm that now you are kicked before any other interaction like in the 2nd image from above.

