### PR TITLE
Bg fix issue with e2e

### DIFF
--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -360,7 +360,13 @@ export const handleChannelCapture = async (
   ]);
 
   const { ENVIRONMENT, HELPLINE_CODE } = context;
-  const languageSanitized = language.replace('-', '_'); // Lex doesn't accept '-'
+  let languageSanitized = language.replace('-', '_'); // Lex doesn't accept '-'
+
+  //This is used to match all digits (0-9) and replace them with no space since Lex doesn't accept numbers
+  if(/\d/.test(languageSanitized)){
+    languageSanitized = languageSanitized.replace('/\d/g', '')
+  }
+
   const botName = `${ENVIRONMENT}_${HELPLINE_CODE.toLowerCase()}_${languageSanitized}_${botSuffix}`;
 
   const options: CaptureChannelOptions = {

--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -364,7 +364,7 @@ export const handleChannelCapture = async (
 
   // This is used to match all digits (0-9) and replace them with no space since Lex doesn't accept numbers
   if (/\d/.test(languageSanitized)) {
-    languageSanitized = languageSanitized.replace(/d/g, '');
+    languageSanitized = languageSanitized.replace(/\d/g, '');
   }
 
   const botName = `${ENVIRONMENT}_${HELPLINE_CODE.toLowerCase()}_${languageSanitized}_${botSuffix}`;

--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -362,9 +362,9 @@ export const handleChannelCapture = async (
   const { ENVIRONMENT, HELPLINE_CODE } = context;
   let languageSanitized = language.replace('-', '_'); // Lex doesn't accept '-'
 
-  //This is used to match all digits (0-9) and replace them with no space since Lex doesn't accept numbers
-  if(/\d/.test(languageSanitized)){
-    languageSanitized = languageSanitized.replace('/\d/g', '')
+  // This is used to match all digits (0-9) and replace them with no space since Lex doesn't accept numbers
+  if (/\d/.test(languageSanitized)) {
+    languageSanitized = languageSanitized.replace(/d/g, '');
   }
 
   const botName = `${ENVIRONMENT}_${HELPLINE_CODE.toLowerCase()}_${languageSanitized}_${botSuffix}`;


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- This PR looks into handling a situation where the helpline code contains a number. It would match all digits (0-9) and replace them with no space since Lex doesn't accept numbers.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
