### PR TITLE
[Modica POC] Modica serverless functions

### DIFF
--- a/functions/helpers/customChannels/customChannelToFlex.private.ts
+++ b/functions/helpers/customChannels/customChannelToFlex.private.ts
@@ -116,6 +116,7 @@ export enum AseloCustomChannels {
   Twitter = 'twitter',
   Instagram = 'instagram',
   Line = 'line',
+  Modica = 'modica',
 }
 
 export const isAseloCustomChannel = (s: unknown): s is AseloCustomChannels =>

--- a/functions/webhooks/modica/FlexToModica.protected.ts
+++ b/functions/webhooks/modica/FlexToModica.protected.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
+import fetch from 'node-fetch';
+import '@twilio-labs/serverless-runtime-types';
+import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  error400,
+  error500,
+  success,
+} from '@tech-matters/serverless-helpers';
+import {
+  WebhookEvent,
+  FlexToCustomChannel,
+} from '../../helpers/customChannels/flexToCustomChannel.private';
+
+// This can be a candidate to be an environment variable
+const MODICA_SEND_MESSAGE_URL = 'https://api.modicagroup.com/rest/gateway/messages';
+
+type EnvVars = {
+  MODICA_APP_NAME: string;
+  MODICA_APP_PASSWORD: string;
+  CHAT_SERVICE_SID: string;
+};
+
+export type Body = Partial<WebhookEvent> & {
+  recipientId?: string; // The phone number of the user that started the conversation. Provided as query parameter
+};
+
+/**
+ * This function adds a '+' symbol at the beginning of the recipientId if it's missing.
+ * Modica expects the destination to be in E.164 format.
+ *
+ * Not sure why recipientId is not including the '+' symbol at the beginning.
+ * Chances are it's an encoding issue, because it's being passed as a query parameter.
+ * Also, it seems it's necessary to trim the recipientId, as well, because it's including
+ * a space at the beginning for some reason.
+ *
+ * See onMessageSentWebhookUrl in ModicaToFlex.ts
+ */
+const sanitizeRecipientId = (recipientIdRaw: string) => {
+  const recipientId = recipientIdRaw.trim();
+
+  if (recipientId.charAt(0) !== '+') {
+    return `+${recipientId}`;
+  }
+
+  return recipientId;
+};
+
+const sendMessageThroughModica =
+  (context: Context<EnvVars>) => async (recipientId: string, messageText: string) => {
+    const payload = {
+      destination: sanitizeRecipientId(recipientId),
+      content: messageText,
+    };
+
+    const base64Credentials = Buffer.from(
+      `${context.MODICA_APP_NAME}:${context.MODICA_APP_PASSWORD}`,
+    ).toString('base64');
+
+    /**
+     * I was struggling to make this call to work with Axios,
+     * so I used node-fetch instead.
+     */
+    const result = await fetch(MODICA_SEND_MESSAGE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${base64Credentials}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!result.ok) {
+      /**
+       * What should we log as error?
+       * The fetch's response might include more useful info.
+       *
+       * Also, we're not using console.error here so we don't get duplicated
+       * errors on Twilio.
+       */
+      console.log('>> Could not send message through Modica');
+    }
+  };
+
+export const handler = async (
+  context: Context<EnvVars>,
+  event: Body,
+  callback: ServerlessCallback,
+) => {
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  try {
+    const { recipientId, Body, From, ChannelSid, EventType, Source } = event;
+    if (recipientId === undefined) {
+      resolve(error400('recipientId'));
+      return;
+    }
+    if (Body === undefined) {
+      resolve(error400('Body'));
+      return;
+    }
+    if (From === undefined) {
+      resolve(error400('From'));
+      return;
+    }
+    if (ChannelSid === undefined) {
+      resolve(error400('ChannelSid'));
+      return;
+    }
+    if (EventType === undefined) {
+      resolve(error400('EventType'));
+      return;
+    }
+    if (Source === undefined) {
+      resolve(error400('Source'));
+      return;
+    }
+
+    const handlerPath = Runtime.getFunctions()['helpers/customChannels/flexToCustomChannel'].path;
+    const flexToCustomChannel = require(handlerPath) as FlexToCustomChannel;
+
+    const sanitizedEvent = {
+      Body,
+      From,
+      ChannelSid,
+      EventType,
+      Source,
+    };
+
+    const result = await flexToCustomChannel.redirectMessageToExternalChat(context, {
+      event: sanitizedEvent,
+      recipientId,
+      sendExternalMessage: sendMessageThroughModica(context),
+    });
+
+    switch (result.status) {
+      case 'sent':
+        resolve(success(result.response));
+        return;
+      case 'ignored':
+        resolve(success('Ignored event.'));
+        return;
+      default:
+        throw new Error('Reached unexpected default case');
+    }
+  } catch (err) {
+    if (err instanceof Error) resolve(error500(err));
+    else resolve(error500(new Error(String(err))));
+  }
+};

--- a/functions/webhooks/modica/ModicaToFlex.ts
+++ b/functions/webhooks/modica/ModicaToFlex.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/* eslint-disable import/no-dynamic-require */
+/* eslint-disable global-require */
+import '@twilio-labs/serverless-runtime-types';
+import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { responseWithCors, bindResolve, error500, success } from '@tech-matters/serverless-helpers';
+
+import { ChannelToFlex } from '../../helpers/customChannels/customChannelToFlex.private';
+
+type EnvVars = {
+  CHAT_SERVICE_SID: string;
+  SYNC_SERVICE_SID: string;
+  MODICA_FLEX_FLOW_SID: string;
+};
+
+export type Event = {
+  source: string;
+  destination: string;
+  content: string;
+};
+
+export const handler = async (
+  context: Context<EnvVars>,
+  event: Event,
+  callback: ServerlessCallback,
+) => {
+  const response = responseWithCors();
+  const resolve = bindResolve(callback)(response);
+
+  try {
+    const { source, destination, content } = event;
+
+    // TODO: Investigate if Modica provides a way to check if the payload is valid.
+
+    const handlerPath = Runtime.getFunctions()['helpers/customChannels/customChannelToFlex'].path;
+    const channelToFlex = require(handlerPath) as ChannelToFlex;
+
+    const messageText = content;
+    const channelType = channelToFlex.AseloCustomChannels.Modica;
+    const subscribedExternalId = destination; // This is  the helpline short code
+    const twilioNumber = `${channelType}:${subscribedExternalId}`;
+    const senderExternalId = source; // This is the child phone number
+    const chatFriendlyName = senderExternalId;
+    const uniqueUserName = `${channelType}:${senderExternalId}`;
+    const senderScreenName = 'child'; // TODO: Should we display something else here?
+    const onMessageSentWebhookUrl = `https://${context.DOMAIN_NAME}/webhooks/modica/FlexToModica?recipientId=${senderExternalId}`;
+
+    // eslint-disable-next-line no-await-in-loop
+    const result = await channelToFlex.sendMessageToFlex(context, {
+      flexFlowSid: context.MODICA_FLEX_FLOW_SID,
+      chatServiceSid: context.CHAT_SERVICE_SID,
+      syncServiceSid: context.SYNC_SERVICE_SID,
+      channelType,
+      twilioNumber,
+      chatFriendlyName,
+      uniqueUserName,
+      senderScreenName,
+      onMessageSentWebhookUrl,
+      messageText,
+      senderExternalId,
+      subscribedExternalId,
+    });
+
+    switch (result.status) {
+      case 'sent':
+        resolve(success(result.response));
+        return;
+      case 'ignored':
+        resolve(success('Ignored event.'));
+        return;
+      default:
+        throw new Error('Reached unexpected default case');
+    }
+  } catch (err: any) {
+    if (err instanceof Error) resolve(error500(err));
+    else resolve(error500(new Error(String(err))));
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "form-data": "^4.0.0",
         "lodash": "4.17.21",
         "moment-timezone": "0.5.37",
+        "node-fetch": "^2.7.0",
         "swagger-ui-express": "4.5.0",
         "twilio": "3.81.0",
         "twilio-flex-token-validator": "1.5.6",
@@ -7437,6 +7438,25 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12965,6 +12985,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -13672,6 +13697,20 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -19565,6 +19604,14 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -23911,6 +23958,11 @@
         }
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -24445,6 +24497,20 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "go": "npx tsc functions/webhooks/modica/FlexToModica.protected.ts && node functions/webhooks/modica/FlexToModica.protected.js",
     "test": "jest --verbose",
     "start": "npx tsc && twilio-run --env",
     "start:local": "npx tsc && twilio-run --env --port 3030",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "go": "npx tsc functions/webhooks/modica/FlexToModica.protected.ts && node functions/webhooks/modica/FlexToModica.protected.js",
     "test": "jest --verbose",
     "start": "npx tsc && twilio-run --env",
     "start:local": "npx tsc && twilio-run --env --port 3030",
@@ -63,6 +64,7 @@
     "form-data": "^4.0.0",
     "lodash": "4.17.21",
     "moment-timezone": "0.5.37",
+    "node-fetch": "^2.7.0",
     "swagger-ui-express": "4.5.0",
     "twilio": "3.81.0",
     "twilio-flex-token-validator": "1.5.6",


### PR DESCRIPTION
## Description
- This PR adds support for Modica-SMS on the serverless level
- ModicaToFlex will forward messages from Modica into Aselo
  - This is a public function and will be the webhook URL on Modica's platform
- FlexToModica is a protected function responsible to forward messages from Flex to Modica

This PR can be merged with no harm.

TODO:
- Check if Modica provides a way to verify the payload being sent
- Maybe investigate why we need to sanitize the user number
  - currently it drops the '+' symbol and adds some white space
  - we have a function to handle this, but I'm not sure why this happens  
- Update GitHub Workflows to add Modica's environment variables
  -  This should be a custom-action, because only one (or a few) helpline(s) uses Modica
- Better error handling
  - This PR only logs `Could not send message through Modica`

Related front-end PR: https://github.com/techmatters/flex-plugins/pull/1974
