### PR TITLE
CHI-2518 Better error handling when sending a message through Modica

### DIFF
--- a/functions/webhooks/modica/FlexToModica.protected.ts
+++ b/functions/webhooks/modica/FlexToModica.protected.ts
@@ -31,6 +31,21 @@ import {
   FlexToCustomChannel,
 } from '../../helpers/customChannels/flexToCustomChannel.private';
 
+class ModicaError extends Error {
+  status: number;
+
+  statusText: string;
+
+  data: any;
+
+  constructor(status: number, statusText: string, json: any) {
+    super(json);
+    this.status = status;
+    this.statusText = statusText;
+    this.data = json;
+  }
+}
+
 // This can be a candidate to be an environment variable
 const MODICA_SEND_MESSAGE_URL = 'https://api.modicagroup.com/rest/gateway/messages';
 
@@ -91,13 +106,10 @@ const sendMessageThroughModica =
 
     if (!result.ok) {
       /**
-       * What should we log as error?
-       * The fetch's response might include more useful info.
-       *
-       * Also, we're not using console.error here so we don't get duplicated
-       * errors on Twilio.
+       * Modica returns a json when the request fails.
        */
-      console.log('>> Could not send message through Modica');
+      const json = await result.json();
+      throw new ModicaError(result.status, result.statusText, json);
     }
   };
 


### PR DESCRIPTION
## Description
This PR adds better error handling for errors on FlexToModica function.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes CHI-2518

### Verification steps
It's a bit hard to mock an error. This is achievable by using Postman.
