### PR TITLE
fix: Resolve partial implementation of getIdentifier [CHI-2605]

### DIFF
--- a/functions/getProfileFlagsForIdentifier.protected.ts
+++ b/functions/getProfileFlagsForIdentifier.protected.ts
@@ -43,7 +43,7 @@ type ChatTrigger = {
     };
   };
 };
-const isChatTrigger = (obj: any): obj is VoiceTrigger =>
+const isChatTrigger = (obj: any): obj is ChatTrigger =>
   obj && obj.message && typeof obj.message === 'object';
 
 type VoiceTrigger = {
@@ -83,9 +83,14 @@ export const getIdentifier = (trigger: Event['trigger']) => {
     if (trigger.message.ChannelAttributes.channel_type === 'whatsapp') {
       return trigger.message.ChannelAttributes.from.replace('whatsapp:', '');
     }
+    if (trigger.message.ChannelAttributes.channel_type === 'modica') {
+      return trigger.message.ChannelAttributes.from.replace('modica:', '');
+    }
     if (trigger.message.ChannelAttributes.channel_type === 'web') {
       return getContactValueFromWebchat(trigger);
     }
+
+    return trigger.message.ChannelAttributes.from;
   }
 
   throw new Error('Trigger is none VoiceTrigger nor ChatTrigger');


### PR DESCRIPTION
## Description
This PR adds the complete list of chat channels to the implementation of `getIdentifier`, in `functions/getProfileFlagsForIdentifier.protected.ts`, following the same pattern as [getNumberFromTask](https://github.com/techmatters/flex-plugins/blob/4c011a18adaac4f2be7ccb46e334f1e31242cdd2/plugin-hrm-form/src/utils/task.ts#L28) from Flex, since that's the identifier that is stored in the database.

NOTE: this PR servers as a quick fix but ~introduces~ doesn't solve some existing tech debt. We should:
- Unify the places where we reference channels across this repo (Twilio serverless functions).
- Try, if possible, to unify the implementation of [getNumberFromTask](https://github.com/techmatters/flex-plugins/blob/4c011a18adaac4f2be7ccb46e334f1e31242cdd2/plugin-hrm-form/src/utils/task.ts#L28), since it's used in two repos (here and in Flex).

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2605)
- [ ] New tests added

### Verification steps
@janorivera will take care of it :) 