### PR TITLE
Fix code for breaking changes in axios v0.26.1 -> v0.28.0 update

### DIFF
--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -457,9 +457,7 @@ const saveSurveyInHRM = async (
     data,
   };
 
-  await axios({
-    url: `${hrmBaseUrl}/postSurveys`,
-    method: 'POST',
+  await axios.post(`${hrmBaseUrl}/postSurveys`, {
     data: JSON.stringify(body),
     headers: {
       'Content-Type': 'application/json',

--- a/functions/getProfileFlagsForIdentifier.protected.ts
+++ b/functions/getProfileFlagsForIdentifier.protected.ts
@@ -113,9 +113,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
     const { trigger } = event;
 
     const identifier = getIdentifier(trigger);
-    const res = await axios({
-      url: `${hrmBaseUrl}/profiles/identifier/${identifier}/flags`,
-      method: 'GET',
+    const res = await axios.get(`${hrmBaseUrl}/profiles/identifier/${identifier}/flags`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Basic ${context.HRM_STATIC_KEY}`,

--- a/functions/reportToIWF.ts
+++ b/functions/reportToIWF.ts
@@ -109,9 +109,7 @@ export const handler = TokenValidator(
         'base64',
       );
 
-      const report = await axios({
-        url: context.IWF_API_URL,
-        method: 'POST',
+      const report = await axios.post(context.IWF_API_URL, {
         data: JSON.stringify(body),
         headers: {
           'Content-Type': 'application/json',

--- a/functions/saveContactToSaferNet.ts
+++ b/functions/saveContactToSaferNet.ts
@@ -97,9 +97,7 @@ export const handler: ServerlessFunctionSignature<EnvVars, Body> = async (
       .update(encodeURIComponent(payloadAsString))
       .digest('hex');
 
-    const saferNetResponse = await axios({
-      url: SAFERNET_ENDPOINT,
-      method: 'POST',
+    const saferNetResponse = await axios.post(SAFERNET_ENDPOINT, {
       data: JSON.parse(payloadAsString),
       headers: {
         'Content-Type': 'application/json',

--- a/functions/selfReportToIWF.ts
+++ b/functions/selfReportToIWF.ts
@@ -75,8 +75,6 @@ export const handler = TokenValidator(
       formData.append('user_age_range', body.user_age_range);
 
       const config: AxiosRequestConfig = {
-        method: 'POST',
-        url: context.IWF_API_CASE_URL,
         headers: {
           ...formData.getHeaders(),
         },
@@ -84,7 +82,7 @@ export const handler = TokenValidator(
         validateStatus: () => true,
       };
 
-      const report = await axios(config);
+      const report = await axios.post(context.IWF_API_CASE_URL, config);
 
       const data = report.data as IWFResponse;
 

--- a/functions/webhooks/instagram/FlexToInstagram.protected.ts
+++ b/functions/webhooks/instagram/FlexToInstagram.protected.ts
@@ -52,14 +52,15 @@ const sendInstagramMessage =
       },
     };
 
-    const response = await axios({
-      url: `https://graph.facebook.com/v19.0/me/messages?access_token=${context.FACEBOOK_PAGE_ACCESS_TOKEN}`,
-      method: 'POST',
-      data: JSON.stringify(body),
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await axios.post(
+      `https://graph.facebook.com/v19.0/me/messages?access_token=${context.FACEBOOK_PAGE_ACCESS_TOKEN}`,
+      {
+        data: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-    });
+    );
 
     return response.data;
   };

--- a/functions/webhooks/line/FlexToLine.protected.ts
+++ b/functions/webhooks/line/FlexToLine.protected.ts
@@ -55,9 +55,7 @@ const sendLineMessage =
       ],
     };
 
-    return axios({
-      url: LINE_SEND_MESSAGE_URL,
-      method: 'POST',
+    return axios.post(LINE_SEND_MESSAGE_URL, {
       data: JSON.stringify(payload),
       headers: {
         'Content-Type': 'application/json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8783,6 +8783,15 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/redoc-cli/node_modules/@types/node": {
       "version": "15.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
@@ -20610,6 +20619,14 @@
           "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
           "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
           "dev": true
+        },
+        "@types/mkdirp": {
+          "version": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+          "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*"
+          }
         },
         "@types/node": {
           "version": "15.12.2",

--- a/tests/reportToIWF.test.ts
+++ b/tests/reportToIWF.test.ts
@@ -26,7 +26,9 @@ jest.mock('@tech-matters/serverless-helpers', () => ({
   functionValidator: (handlerFn: any) => handlerFn,
 }));
 
-jest.mock('axios');
+jest.mock('axios', () => ({
+  post: jest.fn(),
+}));
 
 const baseContext = {
   getTwilioClient: (): any => ({}),
@@ -122,9 +124,8 @@ describe('reportToIWF', () => {
   test('Should POST a payload to IWF_API_URL and return 200', async () => {
     let postedPayload: IWFReportPayload | undefined;
     // @ts-ignore
-    axios.mockImplementationOnce((request) => {
+    axios.post.mockImplementationOnce((url, request) => {
       postedPayload = JSON.parse(request.data);
-      console.log('request here', request);
       return Promise.resolve({
         status: 200,
         data: 'Returned ok',
@@ -146,10 +147,9 @@ describe('reportToIWF', () => {
 
     await reportToIWF(baseContext, event, callback);
 
-    expect(axios).toHaveBeenCalledWith(
+    expect(axios.post).toHaveBeenCalledWith(
+      baseContext.IWF_API_URL,
       expect.objectContaining({
-        url: baseContext.IWF_API_URL,
-        method: 'POST',
         data: expect.anything(),
       }),
     );
@@ -159,7 +159,7 @@ describe('reportToIWF', () => {
   test('Extra report details should be copied into POST payload', async () => {
     let postedPayload: IWFReportPayload | undefined;
     // @ts-ignore
-    axios.mockImplementationOnce((request) => {
+    axios.post.mockImplementationOnce((url, request) => {
       postedPayload = JSON.parse(request.data);
       return Promise.resolve({
         status: 200,
@@ -188,10 +188,9 @@ describe('reportToIWF', () => {
       () => {},
     );
 
-    expect(axios).toHaveBeenCalledWith(
+    expect(axios.post).toHaveBeenCalledWith(
+      baseContext.IWF_API_URL,
       expect.objectContaining({
-        url: baseContext.IWF_API_URL,
-        method: 'POST',
         data: expect.anything(),
       }),
     );
@@ -208,7 +207,7 @@ describe('reportToIWF', () => {
   test('Environment variables should override default values in POST', async () => {
     let postedPayload: IWFReportPayload | undefined;
     // @ts-ignore
-    axios.mockImplementationOnce((request) => {
+    axios.post.mockImplementationOnce((url, request) => {
       postedPayload = JSON.parse(request.data);
       return Promise.resolve({
         status: 200,
@@ -233,10 +232,9 @@ describe('reportToIWF', () => {
       () => {},
     );
 
-    expect(axios).toHaveBeenCalledWith(
+    expect(axios.post).toHaveBeenCalledWith(
+      baseContext.IWF_API_URL,
       expect.objectContaining({
-        url: baseContext.IWF_API_URL,
-        method: 'POST',
         data: expect.anything(),
       }),
     );
@@ -251,7 +249,7 @@ describe('reportToIWF', () => {
 
   test('Should return error code if axios call fails (redirect IWF payload)', async () => {
     // @ts-ignore
-    axios.mockImplementationOnce(() =>
+    axios.post.mockImplementationOnce(() =>
       Promise.resolve({
         status: 403,
         data: 'Unauthorized',

--- a/tests/selfReportToIWF.test.ts
+++ b/tests/selfReportToIWF.test.ts
@@ -30,7 +30,9 @@ jest.mock('@tech-matters/serverless-helpers', () => ({
   functionValidator: (handlerFn: any) => handlerFn,
 }));
 
-jest.mock('axios');
+jest.mock('axios', () => ({
+  post: jest.fn(),
+}));
 jest.mock('form-data', () =>
   jest.fn().mockImplementation(() => {
     const data: Record<string, any> = {
@@ -42,6 +44,8 @@ jest.mock('form-data', () =>
     return data;
   }),
 );
+
+const mockAxiosPost = axios.post as jest.MockedFunction<typeof axios.post>;
 
 const baseContext = {
   getTwilioClient: (): any => ({}),
@@ -120,7 +124,7 @@ describe('selfReportToIWF', () => {
     };
 
     // @ts-ignore
-    axios.mockImplementationOnce(async () => ({
+    mockAxiosPost.mockImplementationOnce(async () => ({
       data: {
         result: 'OK',
         message: {
@@ -146,10 +150,9 @@ describe('selfReportToIWF', () => {
       }),
     );
 
-    expect(axios).toHaveBeenCalledWith(
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      baseContext.IWF_API_CASE_URL,
       expect.objectContaining({
-        url: baseContext.IWF_API_CASE_URL,
-        method: 'POST',
         data: expect.objectContaining(expectedFormData),
       }),
     );
@@ -179,10 +182,9 @@ describe('selfReportToIWF', () => {
       () => {},
     );
 
-    expect(axios).toHaveBeenCalledWith(
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      baseContext.IWF_API_CASE_URL,
       expect.objectContaining({
-        url: baseContext.IWF_API_CASE_URL,
-        method: 'POST',
         data: expect.objectContaining(expectedFormData),
       }),
     );


### PR DESCRIPTION
## Description

The update to axios v0.28.0 introduced a breaking change to the root fuction - i.e. calling `axios(...)` rather than `axios.get(...)` or `axios.post(...)`

The return type for this function is now an object that includes the response object as a 'data' property, amongst other things, rather than just returning the response directly

This PR moves all uses of this function to the HTTP method specific functions, which retains the prior behavioutr of returning the response directly

### Checklist
- [ ] Corresponding issue has been opened
- [X] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
Fixes build
Passes unit tests
