### PR TITLE
fix: prevent chatbotCallbackCleanup from calling handleChannelRelease [CHI-2682]

### DIFF
--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -323,12 +323,6 @@ export const handleChannelCapture = async (
     ? JSON.parse(additionControlTaskAttributes)
     : {};
 
-  const channel = await context
-    .getTwilioClient()
-    .chat.v2.services(context.CHAT_SERVICE_SID)
-    .channels(channelSid)
-    .fetch();
-
   const [, controlTask] = await Promise.all([
     // Remove the studio trigger webhooks to prevent this channel to trigger subsequent Studio flows executions
     context
@@ -368,6 +362,12 @@ export const handleChannelCapture = async (
   }
 
   const botName = `${ENVIRONMENT}_${HELPLINE_CODE.toLowerCase()}_${languageSanitized}_${botSuffix}`;
+
+  const channel = await context
+    .getTwilioClient()
+    .chat.v2.services(context.CHAT_SERVICE_SID)
+    .channels(channelSid)
+    .fetch();
 
   const options: CaptureChannelOptions = {
     botName,

--- a/functions/channelCapture/chatbotCallbackCleanup.protected.ts
+++ b/functions/channelCapture/chatbotCallbackCleanup.protected.ts
@@ -98,12 +98,13 @@ export const chatbotCallbackCleanup = async ({
     capturedChannelAttributes?.chatbotCallbackWebhookSid &&
       channel.webhooks().get(capturedChannelAttributes.chatbotCallbackWebhookSid).remove(),
     // Trigger the next step once the channel is released
-    channelCaptureHandlers.handleChannelRelease(
-      context,
-      channel,
-      capturedChannelAttributes,
-      memory,
-    ),
+    capturedChannelAttributes &&
+      channelCaptureHandlers.handleChannelRelease(
+        context,
+        channel,
+        capturedChannelAttributes,
+        memory,
+      ),
   ]);
 
   console.log('Channel unblocked and bot session deleted');


### PR DESCRIPTION
… if the capture failed (capturedChannelAttributes is missing)

## Description
This PR fixes the bug described in the linked Jira ticket below.

The bug occurs because `chatbotCallbackCleanup` function attempts to call `handleChannelRelease` "capture handler", which assumes that it receives a valid `capturedChannelAttributes` with a `controlTaskSid` property.
If the capture entirely fails from the beginning and the channel does not even gets "captured", `capturedChannelAttributes` are mising from channel attributes causing the cleanup to also fail. This leads to "stuck channels" since we couldn't either capture with bot nor release it to send straight to Flex.

The fix for this is to avoid calling `handleChannelRelease` if the `capturedChannelAttributes` object is entirely missing.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2682)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
@janorivera will probably need to give this some testing in NZ staging, since there is where we are seeing this error.
Other way to test this change involve faking failures from the bot (e.g. miss configuring the bot name intentionally in the channel capture widget) and confirming the channel gets to be properly released.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
