### PR TITLE
CHI-2755: Remove use of GH secrets for account SID

### DIFF
--- a/.github/workflows/deploy-multiple-accounts.yml
+++ b/.github/workflows/deploy-multiple-accounts.yml
@@ -51,8 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TWILIO_SSM_PREFIX: ${{matrix.environment_code}}_TWILIO_${{matrix.helpline_code}}
-      TWILIO_ACCOUNT_SID_SECRET_NAME: ${{matrix.helpline_code}}_${{matrix.environment_code}}_ACCOUNT_SID
-      TWILIO_AUTH_TOKEN_SECRET_NAME: ${{matrix.helpline_code}}_${{matrix.environment_code}}_AUTH_TOKEN
       FULL_ENVIRONMENT_NAME: ${{matrix.environment_code == 'PROD' && 'production' || matrix.environment_code == 'STG' && 'staging' || 'development'}}
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +66,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       # Get AWS parameters to setup environment variables for Serverless function
+      # Get AWS parameters to setup environment variables for Serverless function
+      - name: Set Twilio Account SID
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /${{ env.FULL_ENVIRONMENT_NAME }}/twilio/${{matrix.helpline_code}}/account_sid
+          env_variable_name: TWILIO_ACCOUNT_SID
       - name: Set Twilio Sync API key
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
@@ -139,7 +143,7 @@ jobs:
         uses: marvinpinto/action-inject-ssm-secrets@latest
         continue-on-error: true
         with:
-          ssm_parameter: /${{ env.FULL_ENVIRONMENT_NAME }}/aws/${{ secrets[env.TWILIO_ACCOUNT_SID_SECRET_NAME] }}/region
+          ssm_parameter: /${{ env.FULL_ENVIRONMENT_NAME }}/aws/${{ env.TWILIO_ACCOUNT_SID }}/region
           env_variable_name: HELPLINE_AWS_REGION
 
       - name: Set HELPLINE_AWS_REGION to default


### PR DESCRIPTION
## Description

Remove use of deprecated GH secrets for looking up account SID and use the standard SSM parameter instead.

After this I think those secrets can be deleted

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Deploy helplines using the various single & multiple deploy workflows - none should fail or have errors in the output

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
