### PR TITLE
CHI-2758: Fix axios calls

### DIFF
--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -456,8 +456,10 @@ const saveSurveyInHRM = async (
     taskId: controlTask.sid,
     data,
   };
-
-  await axios.post(`${hrmBaseUrl}/postSurveys`, {
+  // Do NOT use axios.post, it will will clobber the Authorization header! https://github.com/axios/axios/issues/891
+  await axios.request({
+    method: 'post',
+    url: `${hrmBaseUrl}/postSurveys`,
     data: JSON.stringify(body),
     headers: {
       'Content-Type': 'application/json',

--- a/functions/reportToIWF.ts
+++ b/functions/reportToIWF.ts
@@ -109,7 +109,9 @@ export const handler = TokenValidator(
         'base64',
       );
 
-      const report = await axios.post(context.IWF_API_URL, {
+      const report = await axios.request({
+        method: 'post',
+        url: context.IWF_API_URL,
         data: JSON.stringify(body),
         headers: {
           'Content-Type': 'application/json',

--- a/functions/saveContactToSaferNet.ts
+++ b/functions/saveContactToSaferNet.ts
@@ -97,7 +97,9 @@ export const handler: ServerlessFunctionSignature<EnvVars, Body> = async (
       .update(encodeURIComponent(payloadAsString))
       .digest('hex');
 
-    const saferNetResponse = await axios.post(SAFERNET_ENDPOINT, {
+    const saferNetResponse = await axios.request({
+      url: SAFERNET_ENDPOINT,
+      method: 'post',
       data: JSON.parse(payloadAsString),
       headers: {
         'Content-Type': 'application/json',

--- a/functions/selfReportToIWF.ts
+++ b/functions/selfReportToIWF.ts
@@ -82,7 +82,11 @@ export const handler = TokenValidator(
         validateStatus: () => true,
       };
 
-      const report = await axios.post(context.IWF_API_CASE_URL, config);
+      const report = await axios.request({
+        method: 'post',
+        url: context.IWF_API_CASE_URL,
+        ...config,
+      });
 
       const data = report.data as IWFResponse;
 

--- a/functions/webhooks/instagram/FlexToInstagram.protected.ts
+++ b/functions/webhooks/instagram/FlexToInstagram.protected.ts
@@ -51,16 +51,15 @@ const sendInstagramMessage =
         text: messageText,
       },
     };
-
-    const response = await axios.post(
-      `https://graph.facebook.com/v19.0/me/messages?access_token=${context.FACEBOOK_PAGE_ACCESS_TOKEN}`,
-      {
-        data: JSON.stringify(body),
-        headers: {
-          'Content-Type': 'application/json',
-        },
+    // Do NOT use axios.post, it will will clobber the Authorization header! https://github.com/axios/axios/issues/891
+    const response = await axios.request({
+      url: `https://graph.facebook.com/v19.0/me/messages?access_token=${context.FACEBOOK_PAGE_ACCESS_TOKEN}`,
+      method: 'post',
+      data: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+    });
 
     return response.data;
   };

--- a/functions/webhooks/line/FlexToLine.protected.ts
+++ b/functions/webhooks/line/FlexToLine.protected.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable global-require */
 /* eslint-disable import/no-dynamic-require */
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { v4 as uuidV4 } from 'uuid';
 import '@twilio-labs/serverless-runtime-types';
 import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
@@ -54,15 +54,31 @@ const sendLineMessage =
         },
       ],
     };
-
-    return axios.post(LINE_SEND_MESSAGE_URL, {
-      data: JSON.stringify(payload),
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Line-Retry-Key': uuidV4(), // Generate a new uuid for each sent message
-        Authorization: `Bearer ${context.LINE_CHANNEL_ACCESS_TOKEN}`,
-      },
-    });
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Line-Retry-Key': uuidV4(), // Generate a new uuid for each sent message
+      Authorization: `Bearer ${context.LINE_CHANNEL_ACCESS_TOKEN}`,
+    };
+    try {
+      // Do NOT use axios.post, it will will clobber the Authorization header! https://github.com/axios/axios/issues/891
+      return await axios.request({
+        method: 'post',
+        url: LINE_SEND_MESSAGE_URL,
+        data: JSON.stringify(payload),
+        headers,
+      });
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      if (axiosError.response) {
+        const { data, status } = axiosError.response;
+        throw new Error(
+          `Line API error: status: ${status}, body: ${
+            typeof data === 'object' ? JSON.stringify(data) : data
+          }`,
+        );
+      }
+      throw error;
+    }
   };
 
 export const handler = async (

--- a/tests/reportToIWF.test.ts
+++ b/tests/reportToIWF.test.ts
@@ -27,7 +27,7 @@ jest.mock('@tech-matters/serverless-helpers', () => ({
 }));
 
 jest.mock('axios', () => ({
-  post: jest.fn(),
+  request: jest.fn(),
 }));
 
 const baseContext = {
@@ -124,7 +124,7 @@ describe('reportToIWF', () => {
   test('Should POST a payload to IWF_API_URL and return 200', async () => {
     let postedPayload: IWFReportPayload | undefined;
     // @ts-ignore
-    axios.post.mockImplementationOnce((url, request) => {
+    axios.request.mockImplementationOnce((request) => {
       postedPayload = JSON.parse(request.data);
       return Promise.resolve({
         status: 200,
@@ -147,9 +147,10 @@ describe('reportToIWF', () => {
 
     await reportToIWF(baseContext, event, callback);
 
-    expect(axios.post).toHaveBeenCalledWith(
-      baseContext.IWF_API_URL,
+    expect(axios.request).toHaveBeenCalledWith(
       expect.objectContaining({
+        method: 'post',
+        url: baseContext.IWF_API_URL,
         data: expect.anything(),
       }),
     );
@@ -159,7 +160,7 @@ describe('reportToIWF', () => {
   test('Extra report details should be copied into POST payload', async () => {
     let postedPayload: IWFReportPayload | undefined;
     // @ts-ignore
-    axios.post.mockImplementationOnce((url, request) => {
+    axios.request.mockImplementationOnce((request) => {
       postedPayload = JSON.parse(request.data);
       return Promise.resolve({
         status: 200,
@@ -188,9 +189,10 @@ describe('reportToIWF', () => {
       () => {},
     );
 
-    expect(axios.post).toHaveBeenCalledWith(
-      baseContext.IWF_API_URL,
+    expect(axios.request).toHaveBeenCalledWith(
       expect.objectContaining({
+        method: 'post',
+        url: baseContext.IWF_API_URL,
         data: expect.anything(),
       }),
     );
@@ -207,7 +209,7 @@ describe('reportToIWF', () => {
   test('Environment variables should override default values in POST', async () => {
     let postedPayload: IWFReportPayload | undefined;
     // @ts-ignore
-    axios.post.mockImplementationOnce((url, request) => {
+    axios.request.mockImplementationOnce((request) => {
       postedPayload = JSON.parse(request.data);
       return Promise.resolve({
         status: 200,
@@ -232,9 +234,10 @@ describe('reportToIWF', () => {
       () => {},
     );
 
-    expect(axios.post).toHaveBeenCalledWith(
-      baseContext.IWF_API_URL,
+    expect(axios.request).toHaveBeenCalledWith(
       expect.objectContaining({
+        method: 'post',
+        url: baseContext.IWF_API_URL,
         data: expect.anything(),
       }),
     );
@@ -249,7 +252,7 @@ describe('reportToIWF', () => {
 
   test('Should return error code if axios call fails (redirect IWF payload)', async () => {
     // @ts-ignore
-    axios.post.mockImplementationOnce(() =>
+    axios.request.mockImplementationOnce(() =>
       Promise.resolve({
         status: 403,
         data: 'Unauthorized',

--- a/tests/selfReportToIWF.test.ts
+++ b/tests/selfReportToIWF.test.ts
@@ -31,7 +31,7 @@ jest.mock('@tech-matters/serverless-helpers', () => ({
 }));
 
 jest.mock('axios', () => ({
-  post: jest.fn(),
+  request: jest.fn(),
 }));
 jest.mock('form-data', () =>
   jest.fn().mockImplementation(() => {
@@ -45,7 +45,7 @@ jest.mock('form-data', () =>
   }),
 );
 
-const mockAxiosPost = axios.post as jest.MockedFunction<typeof axios.post>;
+const mockAxiosRequest = axios.request as jest.MockedFunction<typeof axios.request>;
 
 const baseContext = {
   getTwilioClient: (): any => ({}),
@@ -123,8 +123,7 @@ describe('selfReportToIWF', () => {
       user_age_range: '<13',
     };
 
-    // @ts-ignore
-    mockAxiosPost.mockImplementationOnce(async () => ({
+    mockAxiosRequest.mockImplementationOnce(async () => ({
       data: {
         result: 'OK',
         message: {
@@ -150,9 +149,10 @@ describe('selfReportToIWF', () => {
       }),
     );
 
-    expect(mockAxiosPost).toHaveBeenCalledWith(
-      baseContext.IWF_API_CASE_URL,
+    expect(mockAxiosRequest).toHaveBeenCalledWith(
       expect.objectContaining({
+        method: 'post',
+        url: baseContext.IWF_API_CASE_URL,
         data: expect.objectContaining(expectedFormData),
       }),
     );
@@ -182,9 +182,10 @@ describe('selfReportToIWF', () => {
       () => {},
     );
 
-    expect(mockAxiosPost).toHaveBeenCalledWith(
-      baseContext.IWF_API_CASE_URL,
+    expect(mockAxiosRequest).toHaveBeenCalledWith(
       expect.objectContaining({
+        url: baseContext.IWF_API_CASE_URL,
+        method: 'post',
         data: expect.objectContaining(expectedFormData),
       }),
     );


### PR DESCRIPTION
## Description

Calls to axios.post that were introduced to fix breaking changes in the latest Axios API themselves have an issue where Auth headers are being clobbered - so this replaces them with calls to axios.request

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

* Regression test custom channels
* Regression test CSAM reports

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
