### PR TITLE
CHI-2818: Add support for backend pulling

### DIFF
--- a/functions/channelCapture/captureChannelWithBot.protected.ts
+++ b/functions/channelCapture/captureChannelWithBot.protected.ts
@@ -71,7 +71,7 @@ export const handler = async (
 
     const isConversation =
       (typeof isConversationValue === 'string' && isConversationValue === 'true') ||
-      Boolean(isConversationValue);
+      (typeof isConversationValue === 'boolean' && isConversationValue);
 
     const handlerPath = Runtime.getFunctions()['channelCapture/channelCaptureHandlers'].path;
     const channelCaptureHandlers = require(handlerPath) as ChannelCaptureHandlers;

--- a/functions/pullTask.ts
+++ b/functions/pullTask.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import {
+  bindResolve,
+  error400,
+  functionValidator as TokenValidator,
+  responseWithCors,
+  send,
+  success,
+} from '@tech-matters/serverless-helpers';
+import { AdjustChatCapacityType } from './adjustChatCapacity';
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+};
+
+type Body = {
+  workerSid: string;
+  request: { cookies: {}; headers: {} };
+};
+
+const PULL_ATTEMPT_TIMEOUT_MS = 5000;
+
+const delay = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Increases chat capacity for a worker and then waits a specified period for another task to be assigned from the queue
+ * It polls the workers reservations to see if a new task has been assigned for this period. If a new task is assigned, it returns 200 with the taskSid
+ * If no task is assigned, it returns 404 - no task found? Possible stretching the definition of a 404 slightly here :-).
+ */
+export const handler = TokenValidator(
+  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
+    console.log('==== pullTask ====');
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+    const { workerSid } = event;
+
+    if (!workerSid) return resolve(error400('workerSid'));
+
+    const client = context.getTwilioClient();
+    const { path } = Runtime.getFunctions().adjustChatCapacity;
+
+    // eslint-disable-next-line global-require,import/no-dynamic-require,prefer-destructuring
+    const adjustChatCapacity: AdjustChatCapacityType = require(path).adjustChatCapacity;
+
+    const body = {
+      workerSid,
+      adjustment: 'increase',
+    } as const;
+    const initialWorkerReservationSids = new Set(
+      (
+        await client.taskrouter.workspaces
+          .get(context.TWILIO_WORKSPACE_SID)
+          .workers.get(workerSid)
+          .reservations.list()
+      ).map((r) => r.sid),
+    );
+
+    await adjustChatCapacity(context, body);
+    const pullAttemptExpiry = Date.now() + PULL_ATTEMPT_TIMEOUT_MS;
+
+    // Polling is much more self contained and less messy than event driven with the backend TaskRouter API
+    while (Date.now() < pullAttemptExpiry) {
+      // eslint-disable-next-line no-await-in-loop
+      await delay(500);
+      // eslint-disable-next-line no-await-in-loop
+      const currentReservations = await client.taskrouter.workspaces
+        .get(context.TWILIO_WORKSPACE_SID)
+        .workers.get(workerSid)
+        .reservations.list();
+      for (const reservation of currentReservations) {
+        if (!initialWorkerReservationSids.has(reservation.sid)) {
+          console.log('New task reserved for worker pulled:', reservation.taskSid);
+          resolve(success({ taskPulled: reservation.taskSid }));
+        }
+      }
+    }
+    return resolve(send(404)({ message: 'No task found to pull' }));
+  },
+);

--- a/functions/taskrouterListeners/adjustCapacityListener.private.ts
+++ b/functions/taskrouterListeners/adjustCapacityListener.private.ts
@@ -16,11 +16,11 @@
 
 import { Context } from '@twilio-labs/serverless-runtime-types/types';
 import {
-  EventFields,
   EventType,
   TASK_COMPLETED,
+  EventFields,
   TaskrouterListener,
-} from '@tech-matters/serverless-helpers/lib/taskrouter';
+} from '@tech-matters/serverless-helpers/taskrouter';
 import type { AdjustChatCapacityType } from '../adjustChatCapacity';
 
 export const eventTypes: EventType[] = [TASK_COMPLETED];

--- a/functions/taskrouterListeners/adjustCapacityListener.private.ts
+++ b/functions/taskrouterListeners/adjustCapacityListener.private.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { Context } from '@twilio-labs/serverless-runtime-types/types';
+import {
+  EventFields,
+  EventType,
+  TASK_COMPLETED,
+  TaskrouterListener,
+} from '@tech-matters/serverless-helpers/lib/taskrouter';
+import type { AdjustChatCapacityType } from '../adjustChatCapacity';
+
+export const eventTypes: EventType[] = [TASK_COMPLETED];
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+  CHAT_SERVICE_SID: string;
+};
+
+/**
+ * Checks the event type to determine if the listener should handle the event or not.
+ * If it returns true, the taskrouter will invoke this listener.
+ */
+export const shouldHandle = (event: EventFields) => eventTypes.includes(event.EventType);
+
+export const handleEvent = async (context: Context<EnvVars>, event: EventFields) => {
+  try {
+    const {
+      EventType: eventType,
+      WorkerSid: workerSid,
+      TaskChannelUniqueName: taskChannelUniqueName,
+    } = event;
+    if (taskChannelUniqueName !== 'chat') return;
+    console.log(`===== Executing AdjustCapacityListener for event: ${eventType} =====`);
+    const serviceConfig = await context.getTwilioClient().flexApi.configuration.get().fetch();
+    const {
+      feature_flags: {
+        enable_manual_pulling: enabledManualPulling,
+        enable_backend_manual_pulling: enableBackendManualPulling,
+      },
+    } = serviceConfig.attributes;
+    // TODO: Update to actually enforce the backend manual pulling feature flag
+    if (enabledManualPulling && (enableBackendManualPulling || true)) {
+      const { path } = Runtime.getFunctions().adjustChatCapacity;
+
+      // eslint-disable-next-line global-require,import/no-dynamic-require,prefer-destructuring
+      const adjustChatCapacity: AdjustChatCapacityType = require(path).adjustChatCapacity;
+
+      const body = {
+        workerSid,
+        adjustment: 'decrease',
+      } as const;
+
+      await adjustChatCapacity(context, body);
+      console.log('===== AdjustCapacityListener successful =====');
+    } else {
+      console.log('===== AdjustCapacityListener skipped - flag not enabled =====');
+    }
+  } catch (err) {
+    console.log('===== AdjustCapacityListener has failed =====');
+    console.log(String(err));
+    throw err;
+  }
+};
+
+/**
+ * The taskrouter callback expects that all taskrouter listeners return
+ * a default object of type TaskrouterListener.
+ */
+const adjustCapacityListener: TaskrouterListener = {
+  shouldHandle,
+  handleEvent,
+};
+
+export default adjustCapacityListener;

--- a/functions/taskrouterListeners/adjustCapacityListener.private.ts
+++ b/functions/taskrouterListeners/adjustCapacityListener.private.ts
@@ -52,8 +52,8 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
         enable_backend_manual_pulling: enableBackendManualPulling,
       },
     } = serviceConfig.attributes;
-    // TODO: Update to actually enforce the backend manual pulling feature flag
-    if (enabledManualPulling && (enableBackendManualPulling || true)) {
+
+    if (enabledManualPulling && enableBackendManualPulling) {
       const { path } = Runtime.getFunctions().adjustChatCapacity;
 
       // eslint-disable-next-line global-require,import/no-dynamic-require,prefer-destructuring


### PR DESCRIPTION
## Description

This is an attempt to fix the manual pulling issue where transfers leave the worker with too high a chat capacity

The theory is that the flex event we rely on is not fired when the task is completed outside of flex, so we are moving he whole function out of flex and into task router events, where events should be consistent and respected

* Adds a listener to reduce chat capacity of the worker once the task is completed (replicating flex functionality)
* Adds a 'pullTask' endpoint. This will increase the chat capacity of the worker, poll the reservations for this worker for 5 seconds to see if a new one is added - if it is a task is considered to have successfully been 'pulled' - returns a 200 and the task SID. If there is no new reservation seen in the timeout period, a 404 is returned and the chat capacity is reduced again
* Adds flag to control this behaviour - if not set it assumes manual pulling is managed flex side.

This also needs the changes in this Flex PR to work: TBD

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [X] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
