### PR TITLE
Chi 2811 support media transcripts

### DIFF
--- a/functions/getMediaUrl.ts
+++ b/functions/getMediaUrl.ts
@@ -29,11 +29,11 @@ import {
 } from '@tech-matters/serverless-helpers';
 
 type EnvVars = {
-  TWILIO_ACCOUNT_SID: string;
-  TWILIO_AUTH_TOKEN: string;
+  ACCOUNT_SID: string;
+  AUTH_TOKEN: string;
 };
 
-export type TwilioMediaPayload = {
+export type Body = {
   serviceSid: string;
   mediaSid: string;
 };
@@ -55,13 +55,13 @@ export const handler = TokenValidator(
       if (!serviceSid) return resolve(error400('serviceSid'));
       if (!mediaSid) return resolve(error400('mediaSid'));
 
-      const body: TwilioMediaPayload = {
+      const body: Body = {
         serviceSid,
         mediaSid,
       };
 
-      const username = context.TWILIO_ACCOUNT_SID;
-      const password = context.TWILIO_AUTH_TOKEN;
+      const username = context.ACCOUNT_SID;
+      const password = context.AUTH_TOKEN;
       const url = `https://mcs.us1.twilio.com/v1/Services/${body.serviceSid}/Media/${body.mediaSid}`;
 
       const hash = Buffer.from(`${username}:${password}`).toString('base64');

--- a/functions/getMediaUrl.ts
+++ b/functions/getMediaUrl.ts
@@ -75,7 +75,7 @@ export const handler = TokenValidator(
         validateStatus: () => true, // always resolve the promise to redirect the response in case of response out of 2xx range
       });
 
-      return resolve(send(media.status)(media.data));
+      return resolve(send(media.status)(media.data.links.content_direct_temporary));
     } catch (err) {
       return resolve(error500(err as any));
     }

--- a/functions/getMediaUrl.ts
+++ b/functions/getMediaUrl.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
+import '@twilio-labs/serverless-runtime-types';
+import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import axios from 'axios';
+import {
+  bindResolve,
+  error400,
+  error500,
+  responseWithCors,
+  send,
+  functionValidator as TokenValidator,
+} from '@tech-matters/serverless-helpers';
+
+type EnvVars = {
+  TWILIO_ACCOUNT_SID: string;
+  TWILIO_AUTH_TOKEN: string;
+};
+
+export type TwilioMediaPayload = {
+  serviceSid: string;
+  mediaSid: string;
+};
+
+export type Event = {
+  serviceSid: string;
+  mediaSid: string;
+  request: { cookies: {}; headers: {} };
+};
+
+export const handler = TokenValidator(
+  async (context: Context<EnvVars>, event: Event, callback: ServerlessCallback) => {
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+
+    try {
+      const { serviceSid, mediaSid } = event;
+
+      if (!serviceSid) return resolve(error400('serviceSid'));
+      if (!mediaSid) return resolve(error400('mediaSid'));
+
+      const body: TwilioMediaPayload = {
+        serviceSid,
+        mediaSid,
+      };
+
+      const username = context.TWILIO_ACCOUNT_SID;
+      const password = context.TWILIO_AUTH_TOKEN;
+      const url = `https://mcs.us1.twilio.com/v1/Services/${body.serviceSid}/Media/${body.mediaSid}`;
+
+      const hash = Buffer.from(`${username}:${password}`).toString('base64');
+
+      const media = await axios.request({
+        method: 'get',
+        url,
+        headers: {
+          Authorization: `Basic ${hash}`,
+        },
+        validateStatus: () => true, // always resolve the promise to redirect the response in case of response out of 2xx range
+      });
+
+      return resolve(send(media.status)(media.data));
+    } catch (err) {
+      return resolve(error500(err as any));
+    }
+  },
+);


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- New feature: This is the API call implementation for the Twilio conversations media resource API used to get the temporary URL for media displayed on the transcript(Here is [Flex-plugin PR](https://github.com/techmatters/flex-plugins/pull/2377) )

- Next Course of Action: To implement the unit test for the getMediaUrl function.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

[CHI-2811](https://tech-matters.atlassian.net/browse/CHI-2811)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P


[CHI-2788]: https://tech-matters.atlassian.net/browse/CHI-2788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CHI-2811]: https://tech-matters.atlassian.net/browse/CHI-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ