### PR TITLE
CHI-2818 queue transfer capacity workaround

### DIFF
--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -24,6 +24,7 @@ import {
   send,
   functionValidator as TokenValidator,
 } from '@tech-matters/serverless-helpers';
+import { WorkerChannelInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/worker/workerChannel';
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;
@@ -31,8 +32,30 @@ type EnvVars = {
 
 export type Body = {
   workerSid?: string;
-  adjustment?: 'increase' | 'decrease';
+  adjustment?: 'increase' | 'decrease' | 'increaseUntilCapacityAvailable';
   request: { cookies: {}; headers: {} };
+};
+
+const increaseChatCapacity = async (channel: WorkerChannelInstance, maxMessageCapacity: number) => {
+  if (channel.availableCapacityPercentage > 0) {
+    return {
+      result: { status: 412, message: 'Still have available capacity, no need to increase.' },
+      updatedChannel: channel,
+    };
+  }
+
+  if (!(channel.configuredCapacity < maxMessageCapacity)) {
+    return {
+      result: { status: 412, message: 'Reached the max capacity.' },
+      updatedChannel: channel,
+    };
+  }
+
+  const updatedChannel = await channel.update({ capacity: channel.configuredCapacity + 1 });
+  return {
+    result: { status: 200, message: 'Successfully increased channel capacity' },
+    updatedChannel,
+  };
 };
 
 export const adjustChatCapacity = async (
@@ -59,21 +82,33 @@ export const adjustChatCapacity = async (
   }
 
   const channels = await worker.workerChannels().list();
-  const channel = channels.find((c) => c.taskChannelUniqueName === 'chat');
+  let channel = channels.find((c) => c.taskChannelUniqueName === 'chat');
 
   if (!channel) return { status: 404, message: 'Could not find chat channel.' };
 
   if (body.adjustment === 'increase') {
-    if (channel.availableCapacityPercentage > 0) {
-      return { status: 412, message: 'Still have available capacity, no need to increase.' };
-    }
+    return (await increaseChatCapacity(channel, maxMessageCapacity)).result;
+  }
 
-    if (!(channel.configuredCapacity < maxMessageCapacity)) {
-      return { status: 412, message: 'Reached the max capacity.' };
+  if (body.adjustment === 'increaseUntilCapacityAvailable') {
+    let result: Awaited<ReturnType<typeof increaseChatCapacity>>['result'] = {
+      status: 200,
+      message: '',
+    };
+    while (result.status === 200) {
+      // eslint-disable-next-line no-await-in-loop
+      ({ result, updatedChannel: channel } = await increaseChatCapacity(
+        channel,
+        maxMessageCapacity,
+      ));
     }
-
-    await channel.update({ capacity: channel.configuredCapacity + 1 });
-    return { status: 200, message: 'Successfully increased channel capacity' };
+    if (
+      channel.configuredCapacity === maxMessageCapacity &&
+      channel.availableCapacityPercentage === 0
+    ) {
+      return { status: 412, message: 'Reached the max capacity with no available capacity.' };
+    }
+    return { status: 200, message: 'Adjusted chat capacity until there is capacity available' };
   }
 
   if (body.adjustment === 'decrease') {

--- a/functions/pullTask.ts
+++ b/functions/pullTask.ts
@@ -70,7 +70,13 @@ export const handler = TokenValidator(
       ).map((r) => r.sid),
     );
 
-    await adjustChatCapacity(context, { workerSid, adjustment: 'increase' });
+    const { status } = await adjustChatCapacity(context, {
+      workerSid,
+      adjustment: 'increaseUntilCapacityAvailable',
+    });
+    if (status !== 200) {
+      resolve(error400('Failed to provide available chat capacity'));
+    }
     const pullAttemptExpiry = Date.now() + PULL_ATTEMPT_TIMEOUT_MS;
 
     // Polling is much more self contained and less messy than event driven with the backend TaskRouter API

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -210,6 +210,10 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       console.log('Handling chat transfer accepted...');
 
       const { originalTask: originalTaskSid } = taskAttributes.transferMeta;
+
+      // We need to decrease chat capacity before completing the task, it until the task completed event introduces a race condition
+      // The worker can still be offered another task before capacity is reduced if we don't do it now
+      await decreaseChatCapacity(context, originalTaskSid);
       const client = context.getTwilioClient();
       await client.taskrouter
         .workspaces(context.TWILIO_WORKSPACE_SID)

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -246,6 +246,9 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       console.log('Handling chat transfer to queue entering target queue...');
 
       const { originalTask: originalTaskSid } = taskAttributes.transferMeta;
+
+      // We need to decrease chat capacity before completing the task, it until the task completed event introduces a race condition
+      // The worker can still be offered another task before capacity is reduced if we don't do it now
       await decreaseChatCapacity(context, originalTaskSid);
       const client = context.getTwilioClient();
 

--- a/tests/taskrouterListeners/transfersListener.test.ts
+++ b/tests/taskrouterListeners/transfersListener.test.ts
@@ -147,6 +147,15 @@ const context = {
         throw new Error('Workspace does not exists');
       },
     },
+    flexApi: {
+      configuration: {
+        get: () => ({
+          fetch: async () => ({
+            attributes: { feature_flags: {} },
+          }),
+        }),
+      },
+    },
   }),
   TWILIO_WORKSPACE_SID: 'WSxxx',
 };


### PR DESCRIPTION
## Description

Adds explicit chat capacity reductions for worker with original task after a transfer. THis prevents a race condition where they can be assigned a new task before their chat capacity is decreased due to completing the task

Also adds an 'increaseUntilCapacityAvailable' mode for adjustChatCapactity that will keep increasing chat capacity until capacity becomes available or the max capacity is reached. I was concerened that 'double decreases' could leave a worker with too low a capacity to pull tasks in some scenarios so this works around that

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket - ensure worker and queue transfer scenarios are working

Also, ensure that if a worker picks up 3 tasks, then transfers 1 away, they can still pull yet another from the queue.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
