### PR TITLE
CHI-2818: Change capacity adjustment approach

### DIFF
--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -32,7 +32,7 @@ type EnvVars = {
 
 export type Body = {
   workerSid?: string;
-  adjustment?: 'increase' | 'decrease' | 'increaseUntilCapacityAvailable';
+  adjustment?: 'increase' | 'decrease' | 'increaseUntilCapacityAvailable' | 'setTo1';
   request: { cookies: {}; headers: {} };
 };
 
@@ -118,6 +118,17 @@ export const adjustChatCapacity = async (
 
     // If configuredCapacity is already 1, send status 200 to avoid error on client side
     return { status: 200, message: 'Successfully decreased channel capacity' };
+  }
+
+  if (body.adjustment === 'setTo1') {
+    if (channel.configuredCapacity !== 1) {
+      await channel.update({ capacity: channel.configuredCapacity - 1 });
+      // If configuredCapacity is already 1, send status 200 to avoid error on client side
+      return { status: 200, message: 'Successfully reset channel capacity to 1' };
+    }
+
+    // If configuredCapacity is already 1, send status 200 to avoid error on client side
+    return { status: 200, message: 'Channel capacity already 1, no adjustment made.' };
   }
 
   return { status: 400, message: 'Invalid adjustment argument' };

--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -123,7 +123,7 @@ export const adjustChatCapacity = async (
 
   if (body.adjustment === 'setTo1') {
     if (channel.configuredCapacity !== 1) {
-      await channel.update({ capacity: channel.configuredCapacity - 1 });
+      await channel.update({ capacity: 1 });
       // If configuredCapacity is already 1, send status 200 to avoid error on client side
       return { status: 200, message: 'Successfully reset channel capacity to 1' };
     }

--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -32,6 +32,7 @@ type EnvVars = {
 
 export type Body = {
   workerSid?: string;
+  // 'increase' and 'decease' can be removed once backend manual pulling is enabled everywhere
   adjustment?: 'increase' | 'decrease' | 'increaseUntilCapacityAvailable' | 'setTo1';
   request: { cookies: {}; headers: {} };
 };

--- a/functions/pullTask.ts
+++ b/functions/pullTask.ts
@@ -96,7 +96,7 @@ export const handler = TokenValidator(
         }
       }
     }
-    await adjustChatCapacity(context, { workerSid, adjustment: 'decrease' });
+    await adjustChatCapacity(context, { workerSid, adjustment: 'setTo1' });
     resolve(send(404)({ message: 'No task found to pull' }));
     return undefined;
   },

--- a/functions/taskrouterListeners/adjustCapacityListener.private.ts
+++ b/functions/taskrouterListeners/adjustCapacityListener.private.ts
@@ -17,13 +17,13 @@
 import { Context } from '@twilio-labs/serverless-runtime-types/types';
 import {
   EventType,
-  RESERVATION_COMPLETED,
+  RESERVATION_WRAPUP,
   EventFields,
   TaskrouterListener,
 } from '@tech-matters/serverless-helpers/taskrouter';
 import type { AdjustChatCapacityType } from '../adjustChatCapacity';
 
-export const eventTypes: EventType[] = [RESERVATION_COMPLETED];
+export const eventTypes: EventType[] = [RESERVATION_WRAPUP];
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;

--- a/functions/taskrouterListeners/adjustCapacityListener.private.ts
+++ b/functions/taskrouterListeners/adjustCapacityListener.private.ts
@@ -37,6 +37,13 @@ type EnvVars = {
  */
 export const shouldHandle = (event: EventFields) => eventTypes.includes(event.EventType);
 
+/**
+ * After a reservation is accepted, we reset the capacity to 1
+ * We only need to increase capacity temporarily to accept an additional task under certain circumstances like transfers and manual task pulls
+ * So since for 'regular' auto assigned tasks resetting to 1 is a noop, we can just always reset to 1 when any reservation is accepted / rejected
+ * @param context
+ * @param event
+ */
 export const handleEvent = async (context: Context<EnvVars>, event: EventFields) => {
   try {
     const {
@@ -59,7 +66,6 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
       // eslint-disable-next-line global-require,import/no-dynamic-require,prefer-destructuring
       const adjustChatCapacity: AdjustChatCapacityType = require(path).adjustChatCapacity;
-
       const body = {
         workerSid,
         adjustment: 'setTo1',

--- a/functions/taskrouterListeners/adjustCapacityListener.private.ts
+++ b/functions/taskrouterListeners/adjustCapacityListener.private.ts
@@ -17,13 +17,14 @@
 import { Context } from '@twilio-labs/serverless-runtime-types/types';
 import {
   EventType,
-  RESERVATION_WRAPUP,
+  RESERVATION_ACCEPTED,
+  RESERVATION_REJECTED,
   EventFields,
   TaskrouterListener,
 } from '@tech-matters/serverless-helpers/taskrouter';
 import type { AdjustChatCapacityType } from '../adjustChatCapacity';
 
-export const eventTypes: EventType[] = [RESERVATION_WRAPUP];
+export const eventTypes: EventType[] = [RESERVATION_ACCEPTED, RESERVATION_REJECTED];
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;
@@ -61,7 +62,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
       const body = {
         workerSid,
-        adjustment: 'decrease',
+        adjustment: 'setTo1',
       } as const;
 
       await adjustChatCapacity(context, body);

--- a/functions/taskrouterListeners/adjustCapacityListener.private.ts
+++ b/functions/taskrouterListeners/adjustCapacityListener.private.ts
@@ -17,13 +17,13 @@
 import { Context } from '@twilio-labs/serverless-runtime-types/types';
 import {
   EventType,
-  TASK_COMPLETED,
+  RESERVATION_COMPLETED,
   EventFields,
   TaskrouterListener,
 } from '@tech-matters/serverless-helpers/taskrouter';
 import type { AdjustChatCapacityType } from '../adjustChatCapacity';
 
-export const eventTypes: EventType[] = [TASK_COMPLETED];
+export const eventTypes: EventType[] = [RESERVATION_COMPLETED];
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -312,6 +312,12 @@ export const handler = TokenValidator(
         }).forEach(([key, value]) => {
           console.debug(`${key}:`, value);
         });
+        console.debug('newAttributes:');
+        Object.entries({
+          newAttributes,
+        }).forEach(([key, value]) => {
+          console.debug(`${key}:`, value);
+        });
         const invite = await client.flexApi.v1.interaction
           .get(flexInteractionSid)
           .channels.get(flexInteractionChannelSid)

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -158,7 +158,7 @@ async function increaseChatCapacity(
 
     const body = {
       workerSid: worker?.sid as string,
-      adjustment: 'increase',
+      adjustment: 'increaseUntilCapacityAvailable',
     } as const;
 
     await adjustChatCapacity(context, body);

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -313,9 +313,7 @@ export const handler = TokenValidator(
           console.debug(`${key}:`, value);
         });
         console.debug('newAttributes:');
-        Object.entries({
-          newAttributes,
-        }).forEach(([key, value]) => {
+        Object.entries(newAttributes).forEach(([key, value]) => {
           console.debug(`${key}:`, value);
         });
         const invite = await client.flexApi.v1.interaction

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -310,7 +310,7 @@ export const handler = TokenValidator(
           newAttributes,
           taskChannelUniqueName: originalTask.taskChannelUniqueName,
         }).forEach(([key, value]) => {
-          console.debug(`${key}: ${value}`);
+          console.debug(`${key}:`, value);
         });
         const invite = await client.flexApi.v1.interaction
           .get(flexInteractionSid)

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -278,8 +278,8 @@ export const handler = TokenValidator(
 
         // Create invite to target worker
         const invite = await client.flexApi.v1.interaction
-          .get(originalAttributes.flexInteractionSid)
-          .channels.get(originalAttributes.flexInteractionChannelSid)
+          .get(flexInteractionSid)
+          .channels.get(flexInteractionChannelSid)
           .invites.create({
             routing: {
               properties: {
@@ -301,9 +301,20 @@ export const handler = TokenValidator(
         console.info(
           `Transferring conversations task ${taskSid} to queue ${targetSid} by creating interaction invite.`,
         );
+        Object.entries({
+          flexInteractionSid,
+          flexInteractionChannelSid,
+          TWILIO_CONVERSATIONS_CHAT_TRANSFER_WORKFLOW_SID:
+            context.TWILIO_CONVERSATIONS_CHAT_TRANSFER_WORKFLOW_SID,
+          TWILIO_WORKSPACE_SID: context.TWILIO_WORKSPACE_SID,
+          newAttributes,
+          taskChannelUniqueName: originalTask.taskChannelUniqueName,
+        }).forEach(([key, value]) => {
+          console.debug(`${key}: ${value}`);
+        });
         const invite = await client.flexApi.v1.interaction
-          .get(originalAttributes.flexInteractionSid)
-          .channels.get(originalAttributes.flexInteractionChannelSid)
+          .get(flexInteractionSid)
+          .channels.get(flexInteractionChannelSid)
           .invites.create({
             routing: {
               properties: {


### PR DESCRIPTION
## Description

Instead of incrementing by 1 and decrementing by 1, when we need extra capacity we increase configured capacity until the API reports we have some capacity available (which will effectively be the current number of tasks the worker has going +1). Then when any task (or reservation?) is accepted, we reset the configured capacity to 1. This means that the worker will be 'over capacity' whenever they have manually pulled tasks or accepted transfers in addition to other tasks. I can't see that being 'over capacity' has any ill effects, and it means that there will never be circumstances where a worker incorrectly gets assigned new tasks because their capacity is higher than it ought to be.

So what will happen is:

1. Before manually pulling / being offered a transfer, the workers capacity should always be 1.
2. When the action happens, their capacity gets bumped to however many tasks they currently have +1
3. As soon as the worker accepts or rejects, their capacity is reduced back to 1 - they are 'over capacity'.
4. When they complete their task, their capacity is already too low for new tasks so the race condition isn't a problem, we don't even change capacity on task completion in this model

I've tested this when the worker pulls a task manually then gets offered a transfer before they accept the task they pulled, changing the chat capacity doesn't appear to revoke reservations that are already pending, so this case is covered.

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [X] Feature flags / configuration added (covered by `enable_backend_manual_pulling`

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Test issues raised in original ticket and thorough regression of manual pulling, transfers and their intersection

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
