### PR TITLE
CHI-2894: Improve user channel map error handling

### DIFF
--- a/functions/helpers/customChannels/customChannelToFlex.private.ts
+++ b/functions/helpers/customChannels/customChannelToFlex.private.ts
@@ -15,11 +15,13 @@
  */
 
 import { Context } from '@twilio-labs/serverless-runtime-types/types';
+import type RestException from 'twilio/lib/base/RestException';
 
 export type ConversationSid = `CH${string}`;
 export type ChatChannelSid = `CH${string}`;
 
 const CONVERSATION_CLOSE_TIMEOUT = 'P3D'; // ISO 8601 duration format https://en.wikipedia.org/wiki/ISO_8601
+const TWILIO_ERROR_CODE_SYNC_DOCUMENT_NOT_FOUND = 20404; // https://www.twilio.com/docs/api/errors/20404
 
 /**
  * @deprecated
@@ -45,7 +47,11 @@ export const retrieveChannelFromUserChannelMap = async (
 
     return userChannelMap.data.activeChannelSid;
   } catch (err) {
-    return undefined;
+    const restException = err as RestException;
+    if (restException.code === TWILIO_ERROR_CODE_SYNC_DOCUMENT_NOT_FOUND) {
+      return undefined;
+    }
+    throw err;
   }
 };
 

--- a/tests/webhooks/line/LineToFlex.test.ts
+++ b/tests/webhooks/line/LineToFlex.test.ts
@@ -53,7 +53,11 @@ let documents: any = {
 function documentsMock(doc: string) {
   return {
     fetch: async () => {
-      if (!documents[doc]) throw new Error('Document does not exists');
+      if (!documents[doc]) {
+        const err = new Error('Document does not exists');
+        (err as any).code = 20404; // Twilio not found code
+        throw err;
+      }
 
       return documents[doc];
     },


### PR DESCRIPTION
## Description

Looking up a channel in a user channel map now rethrows any error thrown by the sync service other than 'document not found'

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Regression test custom channels, monitor fullstory post deploy for recurrences of the ticket issue

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
