### PR TITLE
Fix security hole in transitionAgentParticipants

### DIFF
--- a/functions/interaction/interactionChannelParticipants.private.ts
+++ b/functions/interaction/interactionChannelParticipants.private.ts
@@ -20,20 +20,16 @@ import {
   InteractionChannelParticipantListInstance,
   InteractionChannelParticipantStatus,
 } from 'twilio/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelParticipant';
+import { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
 
 export const transitionAgentParticipants = async (
   client: ReturnType<Context<any>['getTwilioClient']>,
   twilioWorkspaceSid: string,
-  taskSid: string,
+  task: TaskInstance,
   targetStatus: InteractionChannelParticipantStatus,
   interactionChannelParticipantSid?: string,
 ): Promise<string[] | { errorType: 'Validation' | 'Exception'; errorMessage: string }> => {
   console.log('==== transitionAgentParticipants ====');
-
-  const task = await client.taskrouter.workspaces
-    .get(twilioWorkspaceSid)
-    .tasks.get(taskSid)
-    .fetch();
   const { flexInteractionSid, flexInteractionChannelSid } = JSON.parse(task.attributes);
 
   if (!flexInteractionSid || !flexInteractionChannelSid) {

--- a/functions/interaction/transitionAgentParticipants.ts
+++ b/functions/interaction/transitionAgentParticipants.ts
@@ -63,13 +63,12 @@ export const handler = TokenValidator(
       .fetch();
     if (
       !roles.includes('supervisor') &&
-      !(await task.reservations().list()).find((r) => r.workerSid !== workerSid)
+      !(await task.reservations().list()).find((r) => r.workerSid === workerSid)
     ) {
       // Only supervisors or workers that currently have a reservation on the task can transition agent participants
       return resolve(error403('You do not have permission to transition agent participants'));
     }
 
-    (await task.reservations().list()).find((r) => r.workerSid);
     try {
       const result = await transitionAgentParticipants(
         context.getTwilioClient(),

--- a/functions/interaction/transitionAgentParticipants.ts
+++ b/functions/interaction/transitionAgentParticipants.ts
@@ -18,12 +18,14 @@ import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-typ
 import {
   bindResolve,
   error400,
+  error403,
   error500,
   functionValidator as TokenValidator,
   responseWithCors,
   success,
 } from '@tech-matters/serverless-helpers';
 import { InteractionChannelParticipantStatus } from 'twilio/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelParticipant';
+import { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
 import { InteractionChannelParticipants } from './interactionChannelParticipants.private';
 
 type EnvVars = {
@@ -35,6 +37,7 @@ type Body = {
   targetStatus: InteractionChannelParticipantStatus;
   interactionChannelParticipantSid?: string;
   request: { cookies: {}; headers: {} };
+  tokenResult: { worker_sid: string; roles: string[] };
 };
 
 /**
@@ -52,11 +55,26 @@ export const handler = TokenValidator(
     const { path } = Runtime.getFunctions()['interaction/interactionChannelParticipants'];
     // eslint-disable-next-line prefer-destructuring,global-require,import/no-dynamic-require
     const { transitionAgentParticipants }: InteractionChannelParticipants = require(path);
+    const { worker_sid: workerSid, roles } = event.tokenResult;
+    const task: TaskInstance = await context
+      .getTwilioClient()
+      .taskrouter.v1.workspaces.get(context.TWILIO_WORKSPACE_SID)
+      .tasks.get(event.taskSid)
+      .fetch();
+    if (
+      !roles.includes('supervisor') &&
+      !(await task.reservations().list()).find((r) => r.workerSid !== workerSid)
+    ) {
+      // Only supervisors or workers that currently have a reservation on the task can transition agent participants
+      return resolve(error403('You do not have permission to transition agent participants'));
+    }
+
+    (await task.reservations().list()).find((r) => r.workerSid);
     try {
       const result = await transitionAgentParticipants(
         context.getTwilioClient(),
         context.TWILIO_WORKSPACE_SID,
-        event.taskSid,
+        task,
         event.targetStatus,
         event.interactionChannelParticipantSid,
       );

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -182,7 +182,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
       const client = context.getTwilioClient();
 
-      await client.taskrouter.workspaces
+      const originalTask = await client.taskrouter.workspaces
         .get(context.TWILIO_WORKSPACE_SID)
         .tasks.get(originalTaskSid)
         .update({
@@ -200,7 +200,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       await transitionAgentParticipants(
         context.getTwilioClient(),
         context.TWILIO_WORKSPACE_SID,
-        originalTaskSid,
+        originalTask,
         'closed',
         taskAttributes.originalParticipantSid,
       );

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -141,7 +141,7 @@ const updateWarmVoiceTransferAttributes = async (
     },
   };
 
-  await client.taskrouter.workspaces
+  await client.taskrouter.v1.workspaces
     .get(context.TWILIO_WORKSPACE_SID)
     .tasks.get(taskSid)
     .update({ attributes: JSON.stringify(updatedAttributes) });
@@ -182,7 +182,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
       const client = context.getTwilioClient();
 
-      const originalTask = await client.taskrouter.workspaces
+      const originalTask = await client.taskrouter.v1.workspaces
         .get(context.TWILIO_WORKSPACE_SID)
         .tasks.get(originalTaskSid)
         .update({
@@ -221,7 +221,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
       const client = context.getTwilioClient();
 
-      await client.taskrouter.workspaces
+      await client.taskrouter.v1.workspaces
         .get(context.TWILIO_WORKSPACE_SID)
         .tasks.get(originalTaskSid)
         .update({
@@ -269,7 +269,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
       const { originalTask: originalTaskSid } = taskAttributes.transferMeta;
       const client = context.getTwilioClient();
-      const workspace = client.taskrouter.workspaces.get(context.TWILIO_WORKSPACE_SID);
+      const workspace = client.taskrouter.v1.workspaces.get(context.TWILIO_WORKSPACE_SID);
       const [originalTask, rejectedTask] = await Promise.all([
         workspace.tasks.get(originalTaskSid).fetch(),
         workspace.tasks.get(taskSid).fetch(),
@@ -338,7 +338,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
       const { originalTask: originalTaskSid, originalReservation } = taskAttributes.transferMeta;
       const client = context.getTwilioClient();
 
-      await client.taskrouter.workspaces
+      await client.taskrouter.v1.workspaces
         .get(context.TWILIO_WORKSPACE_SID)
         .tasks.get(originalTaskSid)
         .reservations(originalReservation)

--- a/tech-matters-serverless-helpers-lib/src/tokenValidator.ts
+++ b/tech-matters-serverless-helpers-lib/src/tokenValidator.ts
@@ -20,7 +20,7 @@ import {
   ServerlessFunctionSignature,
 } from '@twilio-labs/serverless-runtime-types/types';
 
-type TokenValidatorResponse = { worker_sid?: string; roles?: string[] };
+export type TokenValidatorResponse = { worker_sid?: string; roles?: string[] };
 
 const isWorker = (tokenResult: TokenValidatorResponse) =>
   tokenResult.worker_sid && tokenResult.worker_sid.startsWith('WK');

--- a/tests/taskrouterListeners/transfersListener.test.ts
+++ b/tests/taskrouterListeners/transfersListener.test.ts
@@ -27,6 +27,7 @@ import { Context } from '@twilio-labs/serverless-runtime-types/types';
 import { mock } from 'jest-mock-extended';
 import each from 'jest-each';
 
+import { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
 import * as transfersListener from '../../functions/taskrouterListeners/transfersListener.private';
 import helpers from '../helpers';
 
@@ -97,28 +98,40 @@ const tasks: Map<Task> = {
     sid: 'original-task',
     attributes: JSON.stringify(defaultAttributes),
     fetch: () => Promise.resolve(tasks['original-task']),
-    update: jest.fn(),
+    update: jest.fn().mockImplementation((update: Partial<TaskInstance>) => ({
+      ...tasks['original-task'],
+      ...update,
+    })),
     reservations: jest.fn(),
   },
   'second-task': {
     sid: 'second-task',
     attributes: JSON.stringify(defaultAttributes),
     fetch: () => Promise.resolve(tasks['second-task']),
-    update: jest.fn(),
+    update: jest.fn().mockImplementation((update: Partial<TaskInstance>) => ({
+      ...tasks['second-task'],
+      ...update,
+    })),
     reservations: jest.fn(),
   },
   'original-task-warm-voice': {
     sid: 'original-task-warm-voice',
     attributes: JSON.stringify(defaultWarmVoiceAttributes),
     fetch: () => Promise.resolve(tasks['original-task-warm-voice']),
-    update: jest.fn(),
+    update: jest.fn().mockImplementation((update: Partial<TaskInstance>) => ({
+      ...tasks['original-task-warm-voice'],
+      ...update,
+    })),
     reservations: () => originalTaskVoiceReservation,
   },
   'original-task-cold-voice': {
     sid: 'original-task-cold-voice',
     attributes: JSON.stringify(defaultColdVoiceAttributes),
     fetch: () => Promise.resolve(tasks['original-task-cold-voice']),
-    update: jest.fn(),
+    update: jest.fn().mockImplementation((update: Partial<TaskInstance>) => ({
+      ...tasks['original-task-cold-voice'],
+      ...update,
+    })),
     reservations: () => originalTaskVoiceReservation,
   },
 };
@@ -144,11 +157,13 @@ const context = {
   ...mock<Context<EnvVars>>(),
   getTwilioClient: (): any => ({
     taskrouter: {
-      workspaces: {
-        get: (workspaceSID: string) => {
-          if (workspaces[workspaceSID]) return workspaces[workspaceSID];
+      v1: {
+        workspaces: {
+          get: (workspaceSID: string) => {
+            if (workspaces[workspaceSID]) return workspaces[workspaceSID];
 
-          throw new Error('Workspace does not exists');
+            throw new Error('Workspace does not exists');
+          },
         },
       },
     },


### PR DESCRIPTION
## Description

Currently any agent can transition all the agents in a Flex interaction into wrapup, meaning they can potentially end other agent's ongoing tasks. This only affects conversations so does not affect any production helplines

This change only allows the function to be called by workers with the supervisor or who currently hold a reservation for the task

### Checklist
- [ ] Corresponding issue has been opened
- [X] New tests added
- [N/A] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Regression test post surveys, regular contact wrapup and chat transfers on conversations
Try to call the transitionAgentParticipant from postman for a task with a token for a worker who is not a supervisor and does not have a reservation for the target task - it should return a 403

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
