### PR TITLE
CHI-2930: Look up first participant to decide if a custom channel message should be forwarded to the service user

### DIFF
--- a/functions/interaction/transitionAgentParticipants.ts
+++ b/functions/interaction/transitionAgentParticipants.ts
@@ -37,7 +37,7 @@ type Body = {
   targetStatus: InteractionChannelParticipantStatus;
   interactionChannelParticipantSid?: string;
   request: { cookies: {}; headers: {} };
-  tokenResult: { worker_sid: string; roles: string[] };
+  TokenResult: { worker_sid: string; roles: string[] };
 };
 
 /**
@@ -55,7 +55,7 @@ export const handler = TokenValidator(
     const { path } = Runtime.getFunctions()['interaction/interactionChannelParticipants'];
     // eslint-disable-next-line prefer-destructuring,global-require,import/no-dynamic-require
     const { transitionAgentParticipants }: InteractionChannelParticipants = require(path);
-    const { worker_sid: workerSid, roles } = event.tokenResult;
+    const { worker_sid: workerSid, roles } = event.TokenResult;
     const task: TaskInstance = await context
       .getTwilioClient()
       .taskrouter.v1.workspaces.get(context.TWILIO_WORKSPACE_SID)

--- a/tests/interaction/transitionAgentParticipants.test.ts
+++ b/tests/interaction/transitionAgentParticipants.test.ts
@@ -145,7 +145,7 @@ describe('sid for valid task', () => {
         taskSid: 'WT123',
         targetStatus: 'wrapup',
         request: { headers: {}, cookies: {} },
-        tokenResult: { worker_sid: 'WKbob', roles: ['supervisor'] },
+        TokenResult: { worker_sid: 'WKbob', roles: ['supervisor'] },
       },
       callback,
     );
@@ -160,7 +160,7 @@ describe('sid for valid task', () => {
         taskSid: 'WT123',
         targetStatus: 'wrapup',
         request: { headers: {}, cookies: {} },
-        tokenResult: { worker_sid: 'WKworker_with_reservation', roles: ['agent'] },
+        TokenResult: { worker_sid: 'WKworker_with_reservation', roles: ['agent'] },
       },
       callback,
     );
@@ -175,7 +175,7 @@ describe('sid for valid task', () => {
         taskSid: 'WT123',
         targetStatus: 'wrapup',
         request: { headers: {}, cookies: {} },
-        tokenResult: { worker_sid: 'WKworker_with_reservation', roles: [] },
+        TokenResult: { worker_sid: 'WKworker_with_reservation', roles: [] },
       },
       callback,
     );
@@ -196,7 +196,7 @@ describe('sid for valid task', () => {
         taskSid: 'WT123',
         targetStatus: 'wrapup',
         request: { headers: {}, cookies: {} },
-        tokenResult: { worker_sid: 'WKbob', roles: ['agent'] },
+        TokenResult: { worker_sid: 'WKbob', roles: ['agent'] },
       },
       callback,
     );


### PR DESCRIPTION


## Description

Rather than using the participantSid attribute, which only gets set after completing a chatbot, so won't be set in helplines that don't use a chatbot

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- [N/A] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
