### PR TITLE
CHI-2961: Remove explicit queue from routing info for direct conversation transfers

### DIFF
--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -270,12 +270,13 @@ export const handler = TokenValidator(
           `Transferring conversations task ${taskSid} to worker ${targetSid} by creating interaction invite.`,
         );
         // Get task queue
+        /*
         const taskQueues = await client.taskrouter
           .workspaces(context.TWILIO_WORKSPACE_SID)
           .taskQueues.list({ workerSid: targetSid });
 
         const taskQueueSid = taskQueues[0].sid;
-
+        */
         // Create invite to target worker
         const invite = await client.flexApi.v1.interaction
           .get(flexInteractionSid)
@@ -283,7 +284,7 @@ export const handler = TokenValidator(
           .invites.create({
             routing: {
               properties: {
-                queue_sid: taskQueueSid,
+                // queue_sid: taskQueueSid,
                 worker_sid: targetSid,
                 workflow_sid: context.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
                 workspace_sid: context.TWILIO_WORKSPACE_SID,

--- a/tests/transferChatStart.test.ts
+++ b/tests/transferChatStart.test.ts
@@ -623,7 +623,6 @@ describe('Conversations', () => {
     expect(mockedCreateInvite).toHaveBeenCalledWith({
       routing: {
         properties: {
-          queue_sid: 'TQxxx',
           worker_sid: 'WKxxx',
           workflow_sid: baseContext.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
           workspace_sid: baseContext.TWILIO_WORKSPACE_SID,


### PR DESCRIPTION
## Description

So that the workflow is used to assign a queue, rather than one being assigned in code, this PR experiments with removing an explicit queue from the routing information in the Flex Interactions invite. 

This will either force it to use the flow which is also specified, or break it. Let's find out!

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
