### PR TITLE
CHI-2961: converation direct transfer queue

### DIFF
--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -270,12 +270,13 @@ export const handler = TokenValidator(
           `Transferring conversations task ${taskSid} to worker ${targetSid} by creating interaction invite.`,
         );
         // Get task queue
+        /*
         const taskQueues = await client.taskrouter
           .workspaces(context.TWILIO_WORKSPACE_SID)
           .taskQueues.list({ workerSid: targetSid });
 
         const taskQueueSid = taskQueues[0].sid;
-
+        */
         // Create invite to target worker
         const invite = await client.flexApi.v1.interaction
           .get(flexInteractionSid)
@@ -283,7 +284,7 @@ export const handler = TokenValidator(
           .invites.create({
             routing: {
               properties: {
-                queue_sid: taskQueueSid,
+                // queue_sid: taskQueueSid,
                 worker_sid: targetSid,
                 workflow_sid: context.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
                 workspace_sid: context.TWILIO_WORKSPACE_SID,

--- a/tests/transferChatStart.test.ts
+++ b/tests/transferChatStart.test.ts
@@ -623,6 +623,7 @@ describe('Conversations', () => {
     expect(mockedCreateInvite).toHaveBeenCalledWith({
       routing: {
         properties: {
+          queue_sid: 'TQxxx',
           worker_sid: 'WKxxx',
           workflow_sid: baseContext.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
           workspace_sid: baseContext.TWILIO_WORKSPACE_SID,

--- a/tests/transferChatStart.test.ts
+++ b/tests/transferChatStart.test.ts
@@ -623,7 +623,6 @@ describe('Conversations', () => {
     expect(mockedCreateInvite).toHaveBeenCalledWith({
       routing: {
         properties: {
-          queue_sid: 'TQxxx',
           worker_sid: 'WKxxx',
           workflow_sid: baseContext.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
           workspace_sid: baseContext.TWILIO_WORKSPACE_SID,


### PR DESCRIPTION
## Description

Use the 'Everyone' queue for direct transfers if it is available to the target worker. This will make the behaviour a little more consistent

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags / configuration added

### Other Related Issues

None

### Verification steps

Do a direct chat transfer of a conversation but don't accept it yet. 
Check the task on Twilio Console - it should be in the 'Everyone' queue
Repeat for different channels and helplines, it should always be in the 'Everyone' queue if it is visible to the target worker

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
