### PR TITLE
CHI-3005: Don't increase chat capacity for conversation transfers

### DIFF
--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -359,10 +359,10 @@ export const handler = TokenValidator(
           });
 
         newTaskSid = newTask.sid;
-      }
 
-      // Increse the chat capacity for the target worker (if needed)
-      await increaseChatCapacity(context, validationResult);
+        // Increse the chat capacity for the target worker (if needed)
+        await increaseChatCapacity(context, validationResult);
+      }
 
       resolve(success({ taskSid: newTaskSid }));
     } catch (err: any) {


### PR DESCRIPTION
## Description

Because conversations uses an alternative approach for transferring conversations _i think_ (testing to confirm) that spare capacity isn't required to accept a transfer.

Trying to adjust for the incoming convo is having an undesirable effect, because the transferred convo already counts to the workers current chat capacity even though it is not accepted yet. This means that when we do increase capacity to 'current tasks plus one' to make room for the transfer, we are actually making room for another random task

This PR removes that pre-adjustment for conversations chat transfers

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
