### PR TITLE
CHI-2960: Fix call to remove original participant from a conversation during a queue transfer

### DIFF
--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -221,7 +221,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
 
       const client = context.getTwilioClient();
 
-      await client.taskrouter.v1.workspaces
+      const originalTask = await client.taskrouter.v1.workspaces
         .get(context.TWILIO_WORKSPACE_SID)
         .tasks.get(originalTaskSid)
         .update({
@@ -240,7 +240,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
           await transitionAgentParticipants(
             context.getTwilioClient(),
             context.TWILIO_WORKSPACE_SID,
-            originalTaskSid,
+            originalTask,
             'closed',
             taskAttributes.originalParticipantSid,
           );

--- a/functions/taskrouterListeners/transfersListener.private.ts
+++ b/functions/taskrouterListeners/transfersListener.private.ts
@@ -247,6 +247,7 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
         } catch (err) {
           console.error(
             `Error closing original participant ${taskAttributes.originalParticipantSid} from interaction channel ${taskAttributes.conversationSid}`,
+            err,
           );
         }
       }

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -329,7 +329,6 @@ export const handler = TokenValidator(
               properties: {
                 workflow_sid: context.TWILIO_CONVERSATIONS_CHAT_TRANSFER_WORKFLOW_SID,
                 workspace_sid: context.TWILIO_WORKSPACE_SID,
-                queue_sid: targetSid,
                 attributes: newAttributes,
                 task_channel_unique_name: originalTask.taskChannelUniqueName,
               },

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -329,6 +329,7 @@ export const handler = TokenValidator(
               properties: {
                 workflow_sid: context.TWILIO_CONVERSATIONS_CHAT_TRANSFER_WORKFLOW_SID,
                 workspace_sid: context.TWILIO_WORKSPACE_SID,
+                queue_sid: targetSid,
                 attributes: newAttributes,
                 task_channel_unique_name: originalTask.taskChannelUniqueName,
               },


### PR DESCRIPTION
## Description

Fix issue where a task sid was being passed to the call to remove original participants from a conversation during a queue transfer. The function requires a task object

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N./A Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
See ticket

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
