### PR TITLE
Pin back to ubuntu 22 for playwright E2E runner

### DIFF
--- a/.github/workflows/serverless-pre-release-qa.yml
+++ b/.github/workflows/serverless-pre-release-qa.yml
@@ -39,7 +39,8 @@ jobs:
   run-e2e-tests:
     needs: build-and-deploy
 
-    runs-on: ubuntu-latest
+    # Pinned to v22 while https://github.com/microsoft/playwright/issues/30368 is addressed
+    runs-on: ubuntu-22.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
## Description

Ubuntu Runner for Plawright E2E tests in QA release pinned to v22 while https://github.com/microsoft/playwright/issues/30368 is addressed

