### PR TITLE
CHI-3190 Support sending reservations along with task for getTaskAndReservations return

### DIFF
--- a/functions/getTask.ts
+++ b/functions/getTask.ts
@@ -123,7 +123,13 @@ export const handler = TokenValidator(
             /The requested resource \/Workspaces\/WS[a-z0-9]+\/Tasks\/WT[a-z0-9]+ was not found/,
           )
         ) {
-          resolve(send(404)({ message: error.message }));
+          resolve(
+            success({
+              task: undefined,
+              reservationSid: undefined,
+            }),
+          );
+          return;
         }
         resolve(error500(error));
       }

--- a/functions/getTask.ts
+++ b/functions/getTask.ts
@@ -25,7 +25,6 @@ import {
   success,
   functionValidator as TokenValidator,
   error403,
-  send,
 } from '@tech-matters/serverless-helpers';
 
 type EnvVars = {

--- a/functions/getTask.ts
+++ b/functions/getTask.ts
@@ -103,18 +103,18 @@ export const handler = TokenValidator(
         console.log('>>> getTask reservations', reservations);
 
         reservations.forEach((reservation) => {
-          console.log('>>> getTask reservation', reservation);
+          console.log('>>> getTask reservation', reservation.sid);
         });
 
-        const tasks = await context
+        const task = await context
           .getTwilioClient()
           .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
           .tasks(event.taskSid)
           .fetch();
 
-        console.log('>>> tasks', tasks);
+        console.log('>>> task', task);
 
-        resolve(success(tasks));
+        resolve(success({ task, reservationSid: reservations[0].sid }));
       } catch (err) {
         const error = err as Error;
         if (

--- a/functions/getTask.ts
+++ b/functions/getTask.ts
@@ -112,9 +112,11 @@ export const handler = TokenValidator(
           .tasks(event.taskSid)
           .fetch();
 
-        console.log('>>> task', task);
+        const reservationIds = reservations.map((reservation) => reservation.sid);
 
-        resolve(success({ task, reservationSid: reservations[0].sid }));
+        console.log('>>> reservations', reservationIds);
+
+        resolve(success({ task, reservations: reservationIds }));
       } catch (err) {
         const error = err as Error;
         if (

--- a/functions/getTask.ts
+++ b/functions/getTask.ts
@@ -94,12 +94,27 @@ export const handler = TokenValidator(
         return;
       }
       try {
-        const result = await context
+        const reservations = await context
+          .getTwilioClient()
+          .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
+          .tasks(event.taskSid)
+          .reservations.list();
+
+        console.log('>>> getTask reservations', reservations);
+
+        reservations.forEach((reservation) => {
+          console.log('>>> getTask reservation', reservation);
+        });
+
+        const tasks = await context
           .getTwilioClient()
           .taskrouter.workspaces(context.TWILIO_WORKSPACE_SID)
           .tasks(event.taskSid)
           .fetch();
-        resolve(success(result));
+
+        console.log('>>> tasks', tasks);
+
+        resolve(success(tasks));
       } catch (err) {
         const error = err as Error;
         if (

--- a/functions/getTaskAndReservations.ts
+++ b/functions/getTaskAndReservations.ts
@@ -114,7 +114,7 @@ export const handler = TokenValidator(
           .fetch();
 
         return resolve(success({ task, reservations }));
-      } catch (err) {
+      } catch (err: any) {
         const error = err as Error;
         if (
           error.message.match(


### PR DESCRIPTION
## Description
This PR adds functionality to retrieve the reservations for a given task SID. This enhances to retrieval of the conversation media in flex. 

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- Use this function to go through [verification steps here](https://github.com/techmatters/flex-plugins/pull/2753)

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
