### PR TITLE
fix: Handle Lex v1 language formatting [CHI-3329]

### DIFF
--- a/functions/channelCapture/channelCaptureHandlers.private.ts
+++ b/functions/channelCapture/channelCaptureHandlers.private.ts
@@ -61,6 +61,7 @@ export type CapturedChannelAttributes = {
   environment: string;
   helplineCode: string;
   botLanguage: string;
+  botLanguageV1: string;
   botSuffix: string;
   controlTaskSid: string;
   releaseType: ReleaseTypes;
@@ -114,6 +115,7 @@ const updateChannelWithCapture = async (
     environment,
     helplineCode,
     botLanguage,
+    botLanguageV1,
     botSuffix,
     controlTaskSid,
     chatbotCallbackWebhookSid,
@@ -145,6 +147,7 @@ const updateChannelWithCapture = async (
         environment,
         helplineCode,
         botLanguage,
+        botLanguageV1,
         botSuffix,
         controlTaskSid,
         chatbotCallbackWebhookSid,
@@ -171,6 +174,7 @@ type CaptureChannelOptions = {
   environment: string;
   helplineCode: string;
   botLanguage: string;
+  botLanguageV1: string;
   botSuffix: string;
   inputText: string;
   userId: string;
@@ -196,6 +200,7 @@ const triggerWithUserMessage = async (
     helplineCode,
     botSuffix,
     botLanguage,
+    botLanguageV1,
     inputText,
     controlTaskSid,
     releaseType,
@@ -212,6 +217,7 @@ const triggerWithUserMessage = async (
   // trigger Lex first, in order to reduce the time between the creating the webhook and sending the message
   const lexResult = await lexClient.postText(context, {
     botLanguage,
+    botLanguageV1,
     botSuffix,
     enableLexV2,
     environment,
@@ -253,6 +259,7 @@ const triggerWithUserMessage = async (
     environment,
     helplineCode,
     botLanguage,
+    botLanguageV1,
     botSuffix,
     controlTaskSid,
     releaseType,
@@ -312,6 +319,7 @@ const triggerWithNextMessage = async (
     environment,
     helplineCode,
     botLanguage,
+    botLanguageV1,
     botSuffix,
     inputText,
     controlTaskSid,
@@ -369,6 +377,7 @@ const triggerWithNextMessage = async (
     environment,
     helplineCode,
     botLanguage,
+    botLanguageV1,
     botSuffix,
     controlTaskSid,
     releaseType,
@@ -552,6 +561,7 @@ export const handleChannelCapture = async (
     helplineCode: HELPLINE_CODE.toLowerCase(),
     botSuffix,
     botLanguage: languageSanitized.toLowerCase(),
+    botLanguageV1: languageSanitized,
     releaseType,
     studioFlowSid,
     memoryAttribute,

--- a/functions/channelCapture/chatbotCallback.protected.ts
+++ b/functions/channelCapture/chatbotCallback.protected.ts
@@ -129,11 +129,19 @@ export const handler = async (
       const capturedChannelAttributes =
         channelAttributes.capturedChannelAttributes as CapturedChannelAttributes;
 
-      const { botLanguage, botSuffix, enableLexV2, environment, helplineCode, userId } =
-        capturedChannelAttributes;
+      const {
+        botLanguage,
+        botLanguageV1,
+        botSuffix,
+        enableLexV2,
+        environment,
+        helplineCode,
+        userId,
+      } = capturedChannelAttributes;
 
       const lexResult = await lexClient.postText(context, {
         botLanguage,
+        botLanguageV1,
         botSuffix,
         enableLexV2,
         environment,

--- a/functions/channelCapture/chatbotCallbackCleanup.protected.ts
+++ b/functions/channelCapture/chatbotCallbackCleanup.protected.ts
@@ -118,7 +118,7 @@ export const chatbotCallbackCleanup = async ({
     }
   };
 
-  const { botLanguage, botSuffix, enableLexV2, environment, helplineCode, userId } =
+  const { botLanguage, botLanguageV1, botSuffix, enableLexV2, environment, helplineCode, userId } =
     capturedChannelAttributes;
 
   const shouldDeleteSession = botLanguage && botSuffix && environment && helplineCode && userId;
@@ -128,6 +128,7 @@ export const chatbotCallbackCleanup = async ({
     shouldDeleteSession &&
       lexClient.deleteSession(context, {
         botLanguage,
+        botLanguageV1,
         botSuffix,
         enableLexV2,
         environment,

--- a/functions/channelCapture/lexClient.private.ts
+++ b/functions/channelCapture/lexClient.private.ts
@@ -102,16 +102,16 @@ const deleteSessionV1 = async (
 };
 
 const getBotNameV1 = ({
-  botLanguage,
+  botLanguageV1,
   botSuffix,
   environment,
   helplineCode,
 }: {
   environment: string;
   helplineCode: string;
-  botLanguage: string;
+  botLanguageV1: string;
   botSuffix: string;
-}) => `${environment}_${helplineCode}_${botLanguage}_${botSuffix}`;
+}) => `${environment}_${helplineCode}_${botLanguageV1}_${botSuffix}`;
 
 export const LexV1 = {
   postText: postTextV1,
@@ -289,6 +289,7 @@ export const postText = async (
   credentials: AWSCredentials,
   {
     botLanguage,
+    botLanguageV1,
     botSuffix,
     enableLexV2,
     environment,
@@ -300,6 +301,7 @@ export const postText = async (
     environment: string;
     helplineCode: string;
     botLanguage: string;
+    botLanguageV1: string;
     botSuffix: string;
     inputText: string;
     userId: string;
@@ -330,7 +332,7 @@ export const postText = async (
       return res;
     }
 
-    const botName = LexV1.getBotName({ botLanguage, botSuffix, environment, helplineCode });
+    const botName = LexV1.getBotName({ botLanguageV1, botSuffix, environment, helplineCode });
     const botAlias = 'latest'; // Assume we always use the latest published version
 
     const res = await LexV1.postText(credentials, { botAlias, botName, inputText, userId });
@@ -347,6 +349,7 @@ export const deleteSession = async (
   credentials: AWSCredentials,
   {
     botLanguage,
+    botLanguageV1,
     botSuffix,
     enableLexV2,
     environment,
@@ -357,6 +360,7 @@ export const deleteSession = async (
     environment: string;
     helplineCode: string;
     botLanguage: string;
+    botLanguageV1: string;
     botSuffix: string;
     userId: string;
   },
@@ -384,7 +388,7 @@ export const deleteSession = async (
       });
     }
 
-    const botName = LexV1.getBotName({ botLanguage, botSuffix, environment, helplineCode });
+    const botName = LexV1.getBotName({ botLanguageV1, botSuffix, environment, helplineCode });
     const botAlias = 'latest'; // Assume we always use the latest published version
 
     return await LexV1.deleteSession(credentials, { botAlias, botName, userId });

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -78,7 +78,8 @@ const isTriggerPostSurvey = (
  * Checks the event type to determine if the listener should handle the event or not.
  * If it returns true, the taskrouter will invoke this listener.
  */
-export const shouldHandle = (event: EventFields) => eventTypes.includes(event.EventType);
+export const shouldHandle = () => false;
+// export const shouldHandle = (event: EventFields) => eventTypes.includes(event.EventType);
 
 export const handleEvent = async (context: Context<EnvVars>, event: EventFields) => {
   const {

--- a/functions/taskrouterListeners/postSurveyListener.private.ts
+++ b/functions/taskrouterListeners/postSurveyListener.private.ts
@@ -100,6 +100,13 @@ export const handleEvent = async (context: Context<EnvVars>, event: EventFields)
     const serviceConfig = await client.flexApi.configuration.get().fetch();
     const { feature_flags: featureFlags, helplineLanguage } = serviceConfig.attributes;
 
+    if (featureFlags.enable_lambda_post_survey_processing) {
+      console.debug(
+        'enable_lambda_post_survey_processing is set, the post survey handler will be process in twilio lambda.',
+      );
+      return;
+    }
+
     if (featureFlags.enable_post_survey) {
       const { channelSid, conversationSid, channelType, customChannelType } = taskAttributes;
 


### PR DESCRIPTION
## Description
This PR fixes a bug where channel captures fail for Lex v1 after the changes for Lex v2. The reason is that we have inconsistent formatting for Lex v1 bots (some uppercased). The solution to this bug is to store the bot language with the casing provided without any changes, other than the lower case version sanitized one.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3329)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
