### PR TITLE
chore: avoid channel janitor if task is being moved by switchboarding [CHI-3353]

### DIFF
--- a/functions/taskrouterListeners/janitorListener.private.ts
+++ b/functions/taskrouterListeners/janitorListener.private.ts
@@ -110,9 +110,15 @@ const isCleanupCustomChannel = async (
     channelType?: string;
     customChannelType?: string;
     isChatCaptureControl?: boolean;
+    switchboardInProgress?: boolean;
   } & ChatTransferTaskAttributes,
 ) => {
   if (![TASK_DELETED, TASK_SYSTEM_DELETED, TASK_CANCELED].includes(eventType)) {
+    return false;
+  }
+
+  if (taskAttributes.switchboardInProgress) {
+    console.debug('isDeactivateConversationOrchestration? - No, switchboard in progress');
     return false;
   }
 
@@ -136,6 +142,7 @@ const isDeactivateConversationOrchestration = async (
   taskAttributes: {
     channelType?: string;
     isChatCaptureControl?: boolean;
+    switchboardInProgress?: boolean;
   } & ChatTransferTaskAttributes,
 ) => {
   console.debug('isDeactivateConversationOrchestration?');
@@ -145,6 +152,11 @@ const isDeactivateConversationOrchestration = async (
     )
   ) {
     console.debug('isDeactivateConversationOrchestration? - No, wrong event type:', eventType);
+    return false;
+  }
+
+  if (taskAttributes.switchboardInProgress) {
+    console.debug('isDeactivateConversationOrchestration? - No, switchboard in progress');
     return false;
   }
 

--- a/tests/taskrouterListeners/janitorListener.test.ts
+++ b/tests/taskrouterListeners/janitorListener.test.ts
@@ -220,6 +220,16 @@ describe('isCleanupCustomChannel', () => {
         channelType,
       },
     })),
+    ...['web', 'sms', 'whatsapp', 'facebook', ...Object.values(AseloCustomChannels)].map(
+      (channelType) => ({
+        description: `${channelType} is being moved by switchboard`,
+        taskAttributes: {
+          ...customChannelTaskAttributes,
+          channelType,
+          switchboardInProgress: true,
+        },
+      }),
+    ),
   ]).test(
     'canceled task for custom channel $description, should not trigger janitor',
     async ({ taskAttributes }) => {
@@ -280,6 +290,35 @@ describe('isDeactivateConversationOrchestration', () => {
         ...mock<EventFields>(),
         EventType: eventType as EventType,
         TaskAttributes: JSON.stringify({ ...customChannelTaskAttributes, channelType }),
+        TaskChannelUniqueName: 'chat',
+      };
+      await janitorListener.handleEvent(context, event);
+
+      const { channelSid } = customChannelTaskAttributes;
+      expect(mockChannelJanitor).not.toHaveBeenCalledWith(context, { channelSid });
+    },
+  );
+
+  each(
+    // [TASK_WRAPUP, TASK_COMPLETED, TASK_DELETED, TASK_SYSTEM_DELETED, TASK_CANCELED].flatMap(
+    // [TASK_WRAPUP, TASK_COMPLETED].flatMap((eventType) =>
+    [TASK_WRAPUP, TASK_COMPLETED, TASK_DELETED, TASK_SYSTEM_DELETED, TASK_CANCELED].flatMap(
+      (eventType) =>
+        [...Object.values(AseloCustomChannels), 'web', 'sms', 'whatsapp', 'facebook'].map(
+          (channelType) => ({ channelType, eventType }),
+        ),
+    ),
+  ).test(
+    'when switchboardInProgress task attributes is true, eventType $eventType with channelType $channelType, should not trigger janitor',
+    async ({ channelType, eventType }) => {
+      const event = {
+        ...mock<EventFields>(),
+        EventType: eventType as EventType,
+        TaskAttributes: JSON.stringify({
+          ...customChannelTaskAttributes,
+          channelType,
+          switchboardInProgress: true,
+        }),
         TaskChannelUniqueName: 'chat',
       };
       await janitorListener.handleEvent(context, event);


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/flex-plugins/pull/3089.

## Description
This PR ensures that tasks that are `canceled` because of moving tasks between queues when switchboarding is enabled, do not trigger the "chat channel janitor". This is to avoid shutting down the channel, as it needs to be reused for the conversation after tasks are moved between queues.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3353)
- [x] New tests added
- [ ] Feature flags / configuration added


### Verification steps
Refer to related PR.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and the notification to be posted in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P
